### PR TITLE
feat: 메인페이지 WidgetDescriptionCard 컴포넌트 구현

### DIFF
--- a/src/features/main/components/ui/section-divider/SectionDivider.stories.tsx
+++ b/src/features/main/components/ui/section-divider/SectionDivider.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import SectionDivider from './SectionDivider';
+
+const meta: Meta<typeof SectionDivider> = {
+  title: 'MAIN/SectionDivider',
+  component: SectionDivider,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <SectionDivider text="카드를 클릭해 위젯 기능을 미리 확인해보세요" />
+    </div>
+  ),
+};

--- a/src/features/main/components/ui/section-divider/SectionDivider.tsx
+++ b/src/features/main/components/ui/section-divider/SectionDivider.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/utils';
+
+interface SectionDividerProps {
+  text: string;
+  size?: number;
+  className?: string;
+}
+
+function SectionDivider({ text, size = 300, className }: SectionDividerProps) {
+  return (
+    <div
+      className={cn('flex items-center justify-center gap-4 w-full', className)}
+    >
+      <div className="bg-black-500" style={{ height: '1px', width: size }} />
+      <h3 className="h3-semibold">{text}</h3>
+      <div className="bg-black-500" style={{ height: '1px', width: size }} />
+    </div>
+  );
+}
+
+export default SectionDivider;

--- a/src/features/main/components/ui/widget-description-card/WidgetDescriptionCard.stories.tsx
+++ b/src/features/main/components/ui/widget-description-card/WidgetDescriptionCard.stories.tsx
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import WidgetDescriptionCard from './WidgetDescriptionCard';
+
+const meta: Meta<typeof WidgetDescriptionCard> = {
+  title: 'MAIN/WidgetDescriptionCard',
+  component: WidgetDescriptionCard,
+  tags: ['autodocs'],
+  argTypes: {
+    iconName: {
+      control: 'select',
+      options: ['info', 'note', 'file', 'quiz', 'vote', 'question'],
+      description: '표시할 아이콘',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InfoIcon: Story = {
+  args: {
+    iconName: 'info',
+  },
+};
+export const NoteIcon: Story = {
+  args: {
+    iconName: 'note',
+  },
+};
+export const FileIcon: Story = {
+  args: {
+    iconName: 'file',
+  },
+};
+export const QuizIcon: Story = {
+  args: {
+    iconName: 'quiz',
+  },
+};
+export const VoteIcon: Story = {
+  args: {
+    iconName: 'vote',
+  },
+};
+export const QuestionIcon: Story = {
+  args: {
+    iconName: 'question',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      <div className="flex flex-col gap-3 items-center">
+        <WidgetDescriptionCard
+          iconName="info"
+          title="수업 정보"
+          description="수업명, 수업시간, 수업 장소 등 수업의 핵심 정보들을 공지할 수 있습니다."
+        />
+        <WidgetDescriptionCard
+          iconName="note"
+          title="메모장"
+          description="수업의 흐름을 놓치지 않는 실시간 중요한 안내 사항이나 학습 팁을 가볍게 메모하고 공유하세요."
+        />
+        <WidgetDescriptionCard
+          iconName="file"
+          title="파일"
+          description="강의 교안, 참고 링크, 보조 자료를 위젯에 업로드하세요. 학생들이 여기저기 찾을 필요 없이 즉시 내려받을 수 있습니다."
+        />
+        <WidgetDescriptionCard
+          iconName="quiz"
+          title="퀴즈"
+          description="클릭 몇 번으로 복잡한 설정 없이 객관식 퀴즈를 빠르게 생성하고, 학생들의 참여 현황과 결과를 실시간으로 확인하세요."
+        />
+        <WidgetDescriptionCard
+          iconName="vote"
+          title="투표"
+          description="수업 만족도부터 학습 피드백까지, 설문을 통해 학생들의 생각을 빠르게 듣고 수업에 반영할 수 있습니다."
+        />
+        <WidgetDescriptionCard
+          iconName="question"
+          title="질문"
+          description="수업 중 궁금한 점을 자유롭게 질문하고, 실시간으로 답변을 받아보세요."
+        />
+      </div>
+      <div className="flex flex-col gap-3 items-center">
+        <WidgetDescriptionCard
+          isSelected
+          iconName="info"
+          title="수업 정보"
+          description="수업명, 수업시간, 수업 장소 등 수업의 핵심 정보들을 공지할 수 있습니다."
+        />
+        <WidgetDescriptionCard
+          isSelected
+          iconName="note"
+          title="메모장"
+          description="수업의 흐름을 놓치지 않는 실시간 중요한 안내 사항이나 학습 팁을 가볍게 메모하고 공유하세요."
+        />
+        <WidgetDescriptionCard
+          isSelected
+          iconName="file"
+          title="파일"
+          description="강의 교안, 참고 링크, 보조 자료를 위젯에 업로드하세요. 학생들이 여기저기 찾을 필요 없이 즉시 내려받을 수 있습니다."
+        />
+        <WidgetDescriptionCard
+          isSelected
+          iconName="quiz"
+          title="퀴즈"
+          description="클릭 몇 번으로 복잡한 설정 없이 객관식 퀴즈를 빠르게 생성하고, 학생들의 참여 현황과 결과를 실시간으로 확인하세요."
+        />
+        <WidgetDescriptionCard
+          isSelected
+          iconName="vote"
+          title="투표"
+          description="수업 만족도부터 학습 피드백까지, 설문을 통해 학생들의 생각을 빠르게 듣고 수업에 반영할 수 있습니다."
+        />
+        <WidgetDescriptionCard
+          isSelected
+          iconName="question"
+          title="질문"
+          description="수업 중 궁금한 점을 자유롭게 질문하고, 실시간으로 답변을 받아보세요."
+        />
+      </div>
+    </div>
+  ),
+};

--- a/src/features/main/components/ui/widget-description-card/WidgetDescriptionCard.tsx
+++ b/src/features/main/components/ui/widget-description-card/WidgetDescriptionCard.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import WidgetIcon from '@/shared/components/ui/widget-icon/WidgetIcon';
+
+type IconName = 'info' | 'note' | 'file' | 'quiz' | 'vote' | 'question';
+
+const cardVariants = cva(
+  'flex flex-col w-[280px] p-6 pb-12 gap-4 bg-white rounded-2xl border-2 transition-all overflow-hidden text-left',
+  {
+    variants: {
+      iconName: {
+        info: '',
+        note: '',
+        file: '',
+        question: '',
+        vote: '',
+        quiz: '',
+      },
+      isSelected: {
+        false: 'border-black-50 shadow-sm',
+        true: 'shadow-sm',
+      },
+    },
+    compoundVariants: [
+      /* Question */
+      {
+        isSelected: false,
+        iconName: 'question',
+        className: 'bg-widget-question-bg border-widget-question-border',
+      },
+      {
+        isSelected: true,
+        iconName: 'question',
+        className:
+          'bg-widget-question-bg-sel border-widget-question-border-sel',
+      },
+
+      /* Note */
+      {
+        isSelected: false,
+        iconName: 'note',
+        className: 'bg-widget-note-bg border-widget-note-border',
+      },
+      {
+        isSelected: true,
+        iconName: 'note',
+        className: 'bg-widget-note-bg-sel border-widget-note-border-sel',
+      },
+
+      /* File */
+      {
+        isSelected: false,
+        iconName: 'file',
+        className: 'bg-widget-file-bg border-widget-file-border',
+      },
+      {
+        isSelected: true,
+        iconName: 'file',
+        className: 'bg-widget-file-bg-sel border-widget-file-border-sel',
+      },
+
+      /* Quiz */
+      {
+        isSelected: false,
+        iconName: 'quiz',
+        className: 'bg-widget-quiz-bg border-widget-quiz-border',
+      },
+      {
+        isSelected: true,
+        iconName: 'quiz',
+        className: 'bg-widget-quiz-bg-sel border-widget-quiz-border-sel',
+      },
+
+      /* Vote */
+      {
+        isSelected: false,
+        iconName: 'vote',
+        className: 'bg-widget-vote-bg border-widget-vote-border',
+      },
+      {
+        isSelected: true,
+        iconName: 'vote',
+        className: 'bg-widget-vote-bg-sel border-widget-vote-border-sel',
+      },
+    ],
+    defaultVariants: {
+      iconName: 'info',
+      isSelected: false,
+    },
+  },
+);
+
+interface WidgetDescriptionCardProps
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof cardVariants> {
+  iconName: IconName;
+  title: string;
+  description: string;
+}
+
+function WidgetDescriptionCard({
+  iconName,
+  title,
+  description,
+  isSelected = false,
+  onClick,
+  className,
+  style,
+  ...props
+}: WidgetDescriptionCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(cardVariants({ iconName, isSelected }), 'cursor-pointer')}
+      {...props}
+    >
+      <div className="flex items-center gap-2">
+        <WidgetIcon iconName={iconName} size={30} />
+        <span className="body-semibold text-black-500">{title}</span>
+      </div>
+
+      <div className="overflow-y-auto">
+        <p className="description-regular text-black-300">{description}</p>
+      </div>
+    </button>
+  );
+}
+export default WidgetDescriptionCard;


### PR DESCRIPTION
## 📋 PR 요약
메인페이지의 UI 및 가이드 영상 조작에 필요한 WidgetDescriptionCard를 구현하였습니다.
## 🎯 작업 배경 및 이유
메인페이지 UI 구성요소 제작

## 🔗 관련 링크
- Figma: [피그마 디자인](https://www.figma.com/design/nPBmExETGf5NmYGVCD1LR0/composite-%EB%94%94%EC%9E%90%EC%9D%B8?node-id=333-859&t=1zbyeue49NULwsKr-4)
- Slack: [위젯 기본 컴포넌트 스레드](https://composite-official.slack.com/archives/C0A9XH6KN94/p1773565043981819)

## 💻 주요 변경 사항
WidgetDescriptionCard : 메인페이지의 필수요소인 가이드 영상 조작 및 대표 위젯 소개
SectionDivider: 메인페이지에서 WigetDescriptionCard 영역과 Hero, Entrance 영역을 구분하는 구분선

## 🖼️ 스크린샷 / 화면 녹화
<img width="1364" height="857" alt="image" src="https://github.com/user-attachments/assets/e059c699-6848-4b5d-a38b-5c8d33107414" />
<img width="1017" height="292" alt="image" src="https://github.com/user-attachments/assets/35407747-7a7b-465a-9035-ffbd386f2695" />

## 💬 리뷰어에게
피그마 시안과 다르게 구현된 부분이 있다면 알려주시면 감사하겠습니다!