### PR TITLE
feat: 메인페이지 HeroSection 컴포넌트 구현

### DIFF
--- a/src/features/main/components/ui/hero-badge/HeroBadge.stories.tsx
+++ b/src/features/main/components/ui/hero-badge/HeroBadge.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import HeroBadge from './HeroBadge';
+
+const meta: Meta<typeof HeroBadge> = {
+  title: 'MAIN/HeroBadge',
+  component: HeroBadge,
+  tags: ['autodocs'],
+  argTypes: {
+    badgeName: {
+      control: 'text',
+      options: ['module', 'PC', 'chat'],
+      description: '뱃지 텍스트',
+    },
+    label: {
+      control: 'text',
+      description: '뱃지 설명',
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const InfoIcon: Story = {
+  args: {
+    badgeName: 'module',
+    label: '위젯형 대시보드',
+  },
+};
+export const NoteIcon: Story = {
+  args: {
+    badgeName: 'PC',
+    label: '웹 PC 수업 환경',
+  },
+};
+export const FileIcon: Story = {
+  args: {
+    badgeName: 'chat',
+    label: '실시간 피드백',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-row gap-3 items-center">
+        <HeroBadge badgeName="module" label="위젯형 대시보드" />
+        <HeroBadge badgeName="PC" label="웹 PC 수업 환경" />
+        <HeroBadge badgeName="chat" label="실시간 피드백" />
+      </div>
+    </div>
+  ),
+};

--- a/src/features/main/components/ui/hero-badge/HeroBadge.tsx
+++ b/src/features/main/components/ui/hero-badge/HeroBadge.tsx
@@ -1,0 +1,24 @@
+import Badge from '@/shared/components/ui/badge/Badge';
+import Icon from '@/shared/components/ui/icon/Icon';
+
+type BadgeName = 'module' | 'PC' | 'chat';
+
+interface HeroBadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+  badgeName: BadgeName;
+  label: string;
+}
+
+function HeroBadge({ badgeName, label, ...props }: HeroBadgeProps) {
+  return (
+    <Badge
+      size="md"
+      shape="round"
+      className="bg-black-0 border-1 border-black-200 gap-2 px-5 py-[10px]"
+      {...props}
+    >
+      <Icon name={badgeName} size={20} />
+      <span className="text-black-500 body-regular">{label}</span>
+    </Badge>
+  );
+}
+export default HeroBadge;

--- a/src/features/main/components/ui/hero-section/HeroSection.stories.tsx
+++ b/src/features/main/components/ui/hero-section/HeroSection.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import HeroSection from './HeroSection';
+
+const meta: Meta<typeof HeroSection> = {
+  title: 'MAIN/HeroSection',
+  component: HeroSection,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <HeroSection />
+    </div>
+  ),
+};

--- a/src/features/main/components/ui/hero-section/HeroSection.tsx
+++ b/src/features/main/components/ui/hero-section/HeroSection.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/utils';
+import HeroBadge from '../hero-badge/HeroBadge';
+
+interface HeroSectionProps {
+  className?: string;
+}
+
+function HeroSection({ className }: HeroSectionProps) {
+  return (
+    <div className={cn('flex flex-col gap-5', className)}>
+      {/* Hero 영역 */}
+      <div className="flex flex-col gap-5">
+        <h1 className="h1-bold text-black-500">
+          수업 도구를 한 화면에,
+          <span className="text-blue-300 "> Composite</span>
+        </h1>
+        <p className="h3-semibold text-black-500">
+          흩어진 수업 도구, 이제 하나로 연결하세요.
+        </p>
+        <div className="flex flex-col body-regular text-black-500 gap-[14px]">
+          <div>
+            여기저기 흩어져 있어 번거로웠던 수업 도구들을{' '}
+            <span className="text-blue-300 body-semibold">하나의 화면</span>에
+            담았습니다.
+          </div>
+          <div>
+            질문,투표부터 수업에 필요한 모든 도구를{' '}
+            <span className="body-semibold text-blue-300">
+              간단하게 추가하고 사용
+            </span>
+            해보세요.
+          </div>
+        </div>
+      </div>
+      {/* Badge 영역 */}
+      <div className="flex flex-row gap-3 items-center">
+        <HeroBadge badgeName="module" label="위젯형 대시보드" />
+        <HeroBadge badgeName="PC" label="웹 PC 수업 환경" />
+        <HeroBadge badgeName="chat" label="실시간 피드백" />
+      </div>
+    </div>
+  );
+}
+export default HeroSection;

--- a/src/features/main/components/ui/hero-section/HeroSection.tsx
+++ b/src/features/main/components/ui/hero-section/HeroSection.tsx
@@ -1,15 +1,20 @@
 import { cn } from '@/lib/utils';
 import HeroBadge from '../hero-badge/HeroBadge';
 
+const HERO_BADGES = [
+  { id: 'module', name: 'module', label: '위젯형 대시보드' },
+  { id: 'pc', name: 'PC', label: '웹 PC 수업 환경' },
+  { id: 'chat', name: 'chat', label: '실시간 피드백' },
+] as const;
+
 interface HeroSectionProps {
   className?: string;
 }
 
 function HeroSection({ className }: HeroSectionProps) {
   return (
-    <div className={cn('flex flex-col gap-5', className)}>
-      {/* Hero 영역 */}
-      <div className="flex flex-col gap-5">
+    <section className={cn('flex flex-col gap-5', className)}>
+      <header className="flex flex-col gap-5">
         <h1 className="h1-bold text-black-500">
           수업 도구를 한 화면에,
           <span className="text-blue-300 "> Composite</span>
@@ -31,14 +36,15 @@ function HeroSection({ className }: HeroSectionProps) {
             해보세요.
           </div>
         </div>
-      </div>
-      {/* Badge 영역 */}
-      <div className="flex flex-row gap-3 items-center">
-        <HeroBadge badgeName="module" label="위젯형 대시보드" />
-        <HeroBadge badgeName="PC" label="웹 PC 수업 환경" />
-        <HeroBadge badgeName="chat" label="실시간 피드백" />
-      </div>
-    </div>
+      </header>
+      <ul className="flex flex-row items-center gap-3">
+        {HERO_BADGES.map((badge) => (
+          <li key={badge.id}>
+            <HeroBadge badgeName={badge.name} label={badge.label} />
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }
 export default HeroSection;


### PR DESCRIPTION
## 📋 PR 요약
메인페이지에 사용될 서비스 소개글 UI를 구현하였습니다.

## 🎯 작업 배경 및 이유
메인페이지 구성요소 제작

## 🔗 관련 링크
- Figma: [피그마 디자인](https://www.figma.com/design/nPBmExETGf5NmYGVCD1LR0/composite-%EB%94%94%EC%9E%90%EC%9D%B8?node-id=333-859&t=1zbyeue49NULwsKr-4)
- Slack: [위젯 기본 컴포넌트 스레드](https://composite-official.slack.com/archives/C0A9XH6KN94/p1773565043981819)

## 💻 주요 변경 사항
HeroBadge : Hero 영역에 사용되는 소개 뱃지 컴포넌트
HeroSection : 소개글과 뱃지가 포함된 컴포넌트

## 🖼️ 스크린샷 / 화면 녹화
<img width="560" height="241" alt="image" src="https://github.com/user-attachments/assets/2979ef5f-e462-4cd4-872b-9d160fed7682" />


## 💬 리뷰어에게
3번째 뱃지의 경우 피그마상에서 "실시간 대화" 라고 적혀있지만 저희 서비스에 아직 없는 기능이기에 임시로 "실시간 피드백"으로 변경하여 제작하였습니다. 추후 채팅 기능이 구현되면 바꾸겠습니다!