### PR TITLE
feat: 메인페이지 EntranceSection 컴포넌트 구현

### DIFF
--- a/src/features/main/components/ui/entrance-form/EntranceForm.stories.tsx
+++ b/src/features/main/components/ui/entrance-form/EntranceForm.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import EntranceForm from './EntranceForm';
+
+const meta: Meta<typeof EntranceForm> = {
+  title: 'MAIN/EntranceForm',
+  component: EntranceForm,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Example: Story = {
+  render: () => (
+    <div className="flex flex-col">
+      <EntranceForm
+        description="수업 코드를 공유 받았다면?"
+        title="수업에 참여하기"
+        placeholder="수업 코드 입력하기"
+      />
+    </div>
+  ),
+};

--- a/src/features/main/components/ui/entrance-form/EntranceForm.tsx
+++ b/src/features/main/components/ui/entrance-form/EntranceForm.tsx
@@ -34,7 +34,7 @@ function EntranceForm({
         <IconButton
           shape="square"
           iconName="add"
-          className="h-14 w-[75px] bg-blue-300"
+          className="h-12 w-[75px] bg-blue-300"
           onClick={onAction}
         />
       </div>

--- a/src/features/main/components/ui/entrance-form/EntranceForm.tsx
+++ b/src/features/main/components/ui/entrance-form/EntranceForm.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import Input from '@/shared/components/ui/input/Input';
+import IconButton from '@/shared/components/ui/icon-button/IconButton';
+
+interface EntranceFormProps {
+  description: string;
+  title: string;
+  placeholder: string;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onAction?: () => void;
+}
+
+function EntranceForm({
+  description,
+  title,
+  placeholder,
+  value,
+  onChange,
+  onAction,
+}: EntranceFormProps) {
+  return (
+    <div className="flex flex-col gap-[10px] w-full">
+      <div className="body-regular text-black-300">{description}</div>
+      <div className="h3-semibold text-black-500">{title}</div>
+      <div className="flex w-full gap-3">
+        <Input
+          state="default"
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          wrapperClassName="h-12 py-0"
+        />
+        <IconButton
+          shape="square"
+          iconName="add"
+          className="h-14 w-[75px] bg-blue-300"
+          onClick={onAction}
+        />
+      </div>
+    </div>
+  );
+}
+export default EntranceForm;

--- a/src/features/main/components/ui/entrance-form/EntranceForm.tsx
+++ b/src/features/main/components/ui/entrance-form/EntranceForm.tsx
@@ -3,6 +3,7 @@ import Input from '@/shared/components/ui/input/Input';
 import IconButton from '@/shared/components/ui/icon-button/IconButton';
 
 interface EntranceFormProps {
+  id: string;
   description: string;
   title: string;
   placeholder: string;
@@ -12,6 +13,7 @@ interface EntranceFormProps {
 }
 
 function EntranceForm({
+  id,
   description,
   title,
   placeholder,
@@ -19,12 +21,19 @@ function EntranceForm({
   onChange,
   onAction,
 }: EntranceFormProps) {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    onAction?.();
+  };
   return (
-    <div className="flex flex-col gap-[10px] w-full">
+    <form className="flex flex-col gap-[10px] w-full" onSubmit={handleSubmit}>
       <div className="body-regular text-black-300">{description}</div>
-      <div className="h3-semibold text-black-500">{title}</div>
+      <label htmlFor={id} className="h3-semibold text-black-500">
+        {title}
+      </label>
       <div className="flex w-full gap-3">
         <Input
+          id={id}
           state="default"
           placeholder={placeholder}
           value={value}
@@ -32,13 +41,13 @@ function EntranceForm({
           wrapperClassName="h-12 py-0"
         />
         <IconButton
+          type="submit"
           shape="square"
           iconName="add"
           className="h-12 w-[75px] bg-blue-300"
-          onClick={onAction}
         />
       </div>
-    </div>
+    </form>
   );
 }
 export default EntranceForm;

--- a/src/features/main/components/ui/entrance-section/EntranceSection.stories.tsx
+++ b/src/features/main/components/ui/entrance-section/EntranceSection.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import EntranceSection from './EntranceSection';
+
+const meta: Meta<typeof EntranceSection> = {
+  title: 'MAIN/EntranceSection',
+  component: EntranceSection,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Example: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <EntranceSection />
+    </div>
+  ),
+};

--- a/src/features/main/components/ui/entrance-section/EntranceSection.tsx
+++ b/src/features/main/components/ui/entrance-section/EntranceSection.tsx
@@ -12,6 +12,7 @@ function EntranceSection() {
     <div className="flex flex-col pt-5">
       <div className="flex flex-col gap-7">
         <EntranceForm
+          id="join-code"
           description="수업 코드를 공유받았다면?"
           title="수업에 참여하기"
           placeholder="수업 코드 입력하기"
@@ -20,6 +21,7 @@ function EntranceSection() {
           onAction={handleJoin}
         />
         <EntranceForm
+          id="find-code"
           description="이미 수업을 만들었다면?"
           title="내 수업 찾기"
           placeholder="수업 코드 입력하기"

--- a/src/features/main/components/ui/entrance-section/EntranceSection.tsx
+++ b/src/features/main/components/ui/entrance-section/EntranceSection.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import EntranceForm from '../entrance-form/EntranceForm';
+
+function EntranceSection() {
+  const [joinCode, setJoinCode] = useState('');
+  const [findCode, setFindCode] = useState('');
+
+  const handleJoin = () => console.log('수업 참여:', joinCode);
+  const handleFind = () => console.log('수업 찾기:', findCode);
+
+  return (
+    <div className="flex flex-col pt-5">
+      <div className="flex flex-col gap-7">
+        <EntranceForm
+          description="수업 코드를 공유받았다면?"
+          title="수업에 참여하기"
+          placeholder="수업 코드 입력하기"
+          value={joinCode}
+          onChange={(e) => setJoinCode(e.target.value)}
+          onAction={handleJoin}
+        />
+        <EntranceForm
+          description="이미 수업을 만들었다면?"
+          title="내 수업 찾기"
+          placeholder="수업 코드 입력하기"
+          value={findCode}
+          onChange={(e) => setFindCode(e.target.value)}
+          onAction={handleFind}
+        />
+        <button
+          type="button"
+          className="w-full px-10 py-4 bg-blue-300 text-black-0 h1-semibold rounded-[16px] cursor-pointer transition-colors hover:bg-black-100"
+        >
+          + 새 수업 만들기
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default EntranceSection;


### PR DESCRIPTION
## 📋 PR 요약
메인페이지에서 수업 코드와 모달을 실행시키는 Entrance 컴포넌트를 구현하였습니다.

## 🎯 작업 배경 및 이유
메인페이지 구성요소 제작

## 🔗 관련 링크
- Figma: [피그마 디자인](https://www.figma.com/design/nPBmExETGf5NmYGVCD1LR0/composite-%EB%94%94%EC%9E%90%EC%9D%B8?node-id=333-859&t=1zbyeue49NULwsKr-4)
- Slack: [위젯 기본 컴포넌트 스레드](https://composite-official.slack.com/archives/C0A9XH6KN94/p1773565043981819)

## 💻 주요 변경 사항
EntranceForm : 수업코드를 입력받고 버튼이 동작하도록 하는 컴포넌트
EntarnceSection : 수업 참여하기, 수업 찾기, 수업 생성하기 버튼을 포함하고 있는 수업 코드와 관련된 입력을 받는 영역

## 🖼️ 스크린샷 / 화면 녹화
<img width="380" height="386" alt="image" src="https://github.com/user-attachments/assets/48e2a492-d1e7-49c9-b035-c1ec5f3fa661" />
<img width="364" height="140" alt="image" src="https://github.com/user-attachments/assets/af4b368e-26de-43a8-aa99-f2cbf0a482da" />


## 💬 리뷰어에게
현재는 useState 형식으로 구현하였는데 모달과 연결하면서 RHF 형식으로 입력 로직을 바꿔보겠습니다!