### PR TITLE
 feat: 메인 페이지 및 대시보드 페이지 연결 및 세부 포인트 수정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://dapi.composite.kr

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "composite-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.2",
         "@tailwindcss/postcss": "^4.1.18",
         "@tailwindcss/vite": "^4.1.18",
@@ -382,6 +385,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -8557,7 +8613,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "chromatic": "npx chromatic --project-token=chpt_76afb6a52fec853"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@tailwindcss/postcss": "^4.1.18",
     "@tailwindcss/vite": "^4.1.18",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,18 +1,52 @@
+import { useEffect, useRef } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import MainPage from '@/page/main/MainPage';
 import DashBoardPage from '@/page/dashboard/DashBoardPage';
+import { useGetGuestTokenMutation } from '@/features/guest/api/guest.queries';
+import { setAuthToken } from '@/lib/http';
 import './App.css';
+
+function AppContent() {
+  const getGuestTokenMutation = useGetGuestTokenMutation();
+  const initializedRef = useRef(false);
+
+  useEffect(() => {
+    if (initializedRef.current) return;
+    initializedRef.current = true;
+
+    const key = 'composite_guest_token';
+    const token = localStorage.getItem(key);
+
+    if (!token) {
+      getGuestTokenMutation.mutate(
+        { name: 'guest' },
+        {
+          onSuccess: (data) => {
+            localStorage.setItem(key, data.token);
+            setAuthToken(data.token);
+          },
+        },
+      );
+    } else {
+      setAuthToken(token);
+    }
+  }, [getGuestTokenMutation]);
+
+  return (
+    <Routes>
+      <Route path="/" element={<MainPage />} />
+      <Route
+        path="/dashboard/:lessonName/:teacherName"
+        element={<DashBoardPage />}
+      />
+    </Routes>
+  );
+}
 
 function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<MainPage />} />
-        <Route
-          path="/dashboard/:lessonName/:teacherName"
-          element={<DashBoardPage />}
-        />
-      </Routes>
+      <AppContent />
     </BrowserRouter>
   );
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,67 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import MainPage from '@/page/main/MainPage';
 import DashBoardPage from '@/page/dashboard/DashBoardPage';
-import { useGetGuestTokenMutation } from '@/features/guest/api/guest.queries';
-import { setAuthToken } from '@/lib/http';
 import './App.css';
 
 function AppContent() {
-  const getGuestTokenMutation = useGetGuestTokenMutation();
-  const initializedRef = useRef(false);
-  const [isTokenReady, setIsTokenReady] = useState(false);
-
-  useEffect(() => {
-    if (initializedRef.current) return;
-    initializedRef.current = true;
-
-    const key = 'composite_guest_token';
-    const token = localStorage.getItem(key);
-
-    console.log('[App] Token initialization started. Cached token:', !!token);
-
-    if (!token) {
-      console.log('[App] No cached token. Requesting guest credentials...');
-      setTimeout(() => {
-        console.log('[App] Mutation status:', {
-          isPending: getGuestTokenMutation.isPending,
-          isSuccess: getGuestTokenMutation.isSuccess,
-          isError: getGuestTokenMutation.isError,
-          error: getGuestTokenMutation.error,
-        });
-      }, 1000);
-
-      getGuestTokenMutation.mutate(
-        { name: 'guest' },
-        {
-          onSuccess: (data) => {
-            console.log('[App] Guest token received:', data);
-            localStorage.setItem(key, data.token);
-            setAuthToken(data.token);
-            console.log('[App] Auth token set');
-            setIsTokenReady(true);
-          },
-          onError: (error) => {
-            console.error('[App] Guest token request failed:', error);
-            setIsTokenReady(true);
-          },
-        },
-      );
-    } else {
-      console.log('[App] Using cached token');
-      setAuthToken(token);
-      setIsTokenReady(true);
-    }
-  }, [getGuestTokenMutation]);
-
-  if (!isTokenReady) {
-    return (
-      <div className="flex items-center justify-center w-screen h-screen">
-        Loading...
-      </div>
-    );
-  }
-
   return (
     <Routes>
       <Route path="/" element={<MainPage />} />

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -18,21 +18,28 @@ function AppContent() {
     const key = 'composite_guest_token';
     const token = localStorage.getItem(key);
 
+    console.log('[App] Token initialization started. Cached token:', !!token);
+
     if (!token) {
+      console.log('[App] No cached token. Requesting guest credentials...');
       getGuestTokenMutation.mutate(
         { name: 'guest' },
         {
           onSuccess: (data) => {
+            console.log('[App] Guest token received:', data);
             localStorage.setItem(key, data.token);
             setAuthToken(data.token);
+            console.log('[App] Auth token set');
             setIsTokenReady(true);
           },
-          onError: () => {
+          onError: (error) => {
+            console.error('[App] Guest token request failed:', error);
             setIsTokenReady(true);
           },
         },
       );
     } else {
+      console.log('[App] Using cached token');
       setAuthToken(token);
       setIsTokenReady(true);
     }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import MainPage from '@/page/main/MainPage';
 import DashBoardPage from '@/page/dashboard/DashBoardPage';
@@ -9,6 +9,7 @@ import './App.css';
 function AppContent() {
   const getGuestTokenMutation = useGetGuestTokenMutation();
   const initializedRef = useRef(false);
+  const [isTokenReady, setIsTokenReady] = useState(false);
 
   useEffect(() => {
     if (initializedRef.current) return;
@@ -24,13 +25,26 @@ function AppContent() {
           onSuccess: (data) => {
             localStorage.setItem(key, data.token);
             setAuthToken(data.token);
+            setIsTokenReady(true);
+          },
+          onError: () => {
+            setIsTokenReady(true);
           },
         },
       );
     } else {
       setAuthToken(token);
+      setIsTokenReady(true);
     }
   }, [getGuestTokenMutation]);
+
+  if (!isTokenReady) {
+    return (
+      <div className="flex items-center justify-center w-screen h-screen">
+        Loading...
+      </div>
+    );
+  }
 
   return (
     <Routes>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -22,6 +22,15 @@ function AppContent() {
 
     if (!token) {
       console.log('[App] No cached token. Requesting guest credentials...');
+      setTimeout(() => {
+        console.log('[App] Mutation status:', {
+          isPending: getGuestTokenMutation.isPending,
+          isSuccess: getGuestTokenMutation.isSuccess,
+          isError: getGuestTokenMutation.isError,
+          error: getGuestTokenMutation.error,
+        });
+      }, 1000);
+
       getGuestTokenMutation.mutate(
         { name: 'guest' },
         {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,7 +1,20 @@
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import MainPage from '@/page/main/MainPage';
+import DashBoardPage from '@/page/dashboard/DashBoardPage';
 import './App.css';
 
 function App() {
-  return <p>Hello, World!</p>;
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<MainPage />} />
+        <Route
+          path="/dashboard/:lessonName/:teacherName"
+          element={<DashBoardPage />}
+        />
+      </Routes>
+    </BrowserRouter>
+  );
 }
 
 export default App;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,7 +8,7 @@ function AppContent() {
     <Routes>
       <Route path="/" element={<MainPage />} />
       <Route
-        path="/dashboard/:lessonName/:teacherName"
+        path="/dashboard/:lessonCode/:lessonName/:teacherName"
         element={<DashBoardPage />}
       />
     </Routes>

--- a/src/features/dashboard/modal/add-widget-modal/AddWidgetModal.tsx
+++ b/src/features/dashboard/modal/add-widget-modal/AddWidgetModal.tsx
@@ -6,13 +6,14 @@ import { type WidgetName } from '@/shared/types/widget.type';
 interface AddWidgetModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onSelectWidget: (id: WidgetName) => void;
 }
 
-function AddWidgetModal({ isOpen, onClose }: AddWidgetModalProps) {
-  const handleClickWidget = (id: WidgetName) => {
-    console.log(`${id} 위젯이 클릭되었습니다.`);
-  };
-
+function AddWidgetModal({
+  isOpen,
+  onClose,
+  onSelectWidget,
+}: AddWidgetModalProps) {
   return (
     <Modal title="위젯 추가" isOpen={isOpen} onClose={onClose}>
       <ul className="flex flex-col gap-[10px]">
@@ -22,7 +23,7 @@ function AddWidgetModal({ isOpen, onClose }: AddWidgetModalProps) {
               widgetName={widget.id}
               title={widget.title}
               label={widget.label}
-              onClick={() => handleClickWidget(widget.id)}
+              onClick={() => onSelectWidget(widget.id)}
             />
           </li>
         ))}

--- a/src/features/guest/api/guest.api.ts
+++ b/src/features/guest/api/guest.api.ts
@@ -11,9 +11,17 @@ export interface GuestCredentialsResponse {
 export async function getGuestToken(
   body: GuestCredentialsRequest,
 ): Promise<GuestCredentialsResponse> {
-  const response = await http.post<GuestCredentialsResponse>(
-    '/guests/credentials',
-    body,
-  );
-  return response.data;
+  const response = await http.post('/guests/credentials', body);
+  const authorizationHeader =
+    response.headers.authorization || response.headers.Authorization;
+
+  if (!authorizationHeader) {
+    throw new Error('Authorization header not found in response');
+  }
+
+  const token = authorizationHeader.startsWith('Bearer ')
+    ? authorizationHeader.slice(7)
+    : authorizationHeader;
+
+  return { token };
 }

--- a/src/features/guest/api/guest.api.ts
+++ b/src/features/guest/api/guest.api.ts
@@ -11,17 +11,9 @@ export interface GuestCredentialsResponse {
 export async function getGuestToken(
   body: GuestCredentialsRequest,
 ): Promise<GuestCredentialsResponse> {
-  const response = await http.post('/guests/credentials', body);
-  const authorizationHeader =
-    response.headers.authorization || response.headers.Authorization;
-
-  if (!authorizationHeader) {
-    throw new Error('Authorization header not found in response');
-  }
-
-  const token = authorizationHeader.startsWith('Bearer ')
-    ? authorizationHeader.slice(7)
-    : authorizationHeader;
-
-  return { token };
+  const response = await http.post<GuestCredentialsResponse>(
+    '/guests/credentials',
+    body,
+  );
+  return response.data;
 }

--- a/src/features/guest/api/guest.api.ts
+++ b/src/features/guest/api/guest.api.ts
@@ -11,9 +11,17 @@ export interface GuestCredentialsResponse {
 export async function getGuestToken(
   body: GuestCredentialsRequest,
 ): Promise<GuestCredentialsResponse> {
-  const response = await http.post<GuestCredentialsResponse>(
-    '/guests/credentials',
-    body,
-  );
-  return response.data;
+  const response = await http.post('/guests/credentials', body);
+  const authorizationHeader: string =
+    response.headers.authorization || response.headers.Authorization;
+
+  if (!authorizationHeader) {
+    throw new Error('Authorization header not found in response');
+  }
+
+  const token = authorizationHeader.startsWith('Bearer ')
+    ? authorizationHeader.slice(7)
+    : authorizationHeader;
+
+  return { token };
 }

--- a/src/features/guest/api/guest.api.ts
+++ b/src/features/guest/api/guest.api.ts
@@ -1,0 +1,19 @@
+import { http } from '../../../lib/http';
+
+export interface GuestCredentialsRequest {
+  name: string;
+}
+
+export interface GuestCredentialsResponse {
+  token: string;
+}
+
+export async function getGuestToken(
+  body: GuestCredentialsRequest,
+): Promise<GuestCredentialsResponse> {
+  const response = await http.post<GuestCredentialsResponse>(
+    '/guests/credentials',
+    body,
+  );
+  return response.data;
+}

--- a/src/features/guest/api/guest.mock.ts
+++ b/src/features/guest/api/guest.mock.ts
@@ -1,0 +1,13 @@
+import { http, HttpResponse } from 'msw';
+
+export const guestHandlers = [
+  http.post('/guests/credentials', async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json(
+      {
+        token: `guest-token-${body.name}`,
+      },
+      { status: 201 },
+    );
+  }),
+];

--- a/src/features/guest/api/guest.mock.ts
+++ b/src/features/guest/api/guest.mock.ts
@@ -1,15 +1,24 @@
 import { http, HttpResponse } from 'msw';
 
+function encodeBase64(str: string): string {
+  const bytes = new TextEncoder().encode(str);
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+}
+
 function generateMockJWT(name: string): string {
-  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
-  const payload = btoa(
+  const header = encodeBase64(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = encodeBase64(
     JSON.stringify({
       name,
       iat: Math.floor(Date.now() / 1000),
       exp: Math.floor(Date.now() / 1000) + 86400,
     }),
   );
-  const signature = btoa('mock-signature');
+  const signature = encodeBase64('mock-signature');
   return `${header}.${payload}.${signature}`;
 }
 
@@ -18,7 +27,12 @@ export const guestHandlers = [
     try {
       const body = (await request.json()) as Record<string, unknown>;
       const token = generateMockJWT(String(body.name || 'guest'));
-      return HttpResponse.json({ token }, { status: 201 });
+      return new HttpResponse(null, {
+        status: 201,
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
     } catch {
       return HttpResponse.json(
         { error: 'Failed to process request' },

--- a/src/features/guest/api/guest.mock.ts
+++ b/src/features/guest/api/guest.mock.ts
@@ -15,12 +15,15 @@ function generateMockJWT(name: string): string {
 
 export const guestHandlers = [
   http.post('/guests/credentials', async ({ request }) => {
-    const body = (await request.json()) as Record<string, unknown>;
-    return HttpResponse.json(
-      {
-        token: generateMockJWT(String(body.name)),
-      },
-      { status: 201 },
-    );
+    try {
+      const body = (await request.json()) as Record<string, unknown>;
+      const token = generateMockJWT(String(body.name || 'guest'));
+      return HttpResponse.json({ token }, { status: 201 });
+    } catch {
+      return HttpResponse.json(
+        { error: 'Failed to process request' },
+        { status: 400 },
+      );
+    }
   }),
 ];

--- a/src/features/guest/api/guest.mock.ts
+++ b/src/features/guest/api/guest.mock.ts
@@ -1,11 +1,24 @@
 import { http, HttpResponse } from 'msw';
 
+function generateMockJWT(name: string): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = btoa(
+    JSON.stringify({
+      name,
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 86400,
+    }),
+  );
+  const signature = btoa('mock-signature');
+  return `${header}.${payload}.${signature}`;
+}
+
 export const guestHandlers = [
   http.post('/guests/credentials', async ({ request }) => {
     const body = (await request.json()) as Record<string, unknown>;
     return HttpResponse.json(
       {
-        token: `guest-token-${body.name}`,
+        token: generateMockJWT(String(body.name)),
       },
       { status: 201 },
     );

--- a/src/features/guest/api/guest.queries.ts
+++ b/src/features/guest/api/guest.queries.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { getGuestToken, type GuestCredentialsRequest } from './guest.api';
+
+export function useGetGuestTokenMutation() {
+  return useMutation({
+    mutationFn: (body: GuestCredentialsRequest) => getGuestToken(body),
+  });
+}

--- a/src/features/lesson/api/lesson.api.ts
+++ b/src/features/lesson/api/lesson.api.ts
@@ -1,8 +1,11 @@
 import { http } from '../../../lib/http';
 
 export interface Lesson {
-  lessonName: string;
+  id: number;
   teacherName: string;
+  lessonName: string;
+  lessonCode: string;
+  createdTime: string;
 }
 
 export interface CreateLessonRequest {
@@ -43,6 +46,22 @@ export async function fetchLesson(
       Authorization: `Bearer ${guestToken}`,
     },
   });
+  return response.data;
+}
+
+export async function joinLesson(
+  lessonCode: string,
+  guestToken: string,
+): Promise<Lesson> {
+  const response = await http.post<Lesson>(
+    `/lessons/${lessonCode}/students`,
+    {},
+    {
+      headers: {
+        Authorization: `Bearer ${guestToken}`,
+      },
+    },
+  );
   return response.data;
 }
 

--- a/src/features/lesson/api/lesson.api.ts
+++ b/src/features/lesson/api/lesson.api.ts
@@ -25,20 +25,24 @@ export interface AuthenticateLessonResponse {
 
 export async function createLesson(
   body: CreateLessonRequest,
-  user: string,
+  guestToken: string,
 ): Promise<Lesson> {
   const response = await http.post<Lesson>('/lessons', body, {
-    params: { user },
+    headers: {
+      Authorization: `Bearer ${guestToken}`,
+    },
   });
   return response.data;
 }
 
 export async function fetchLesson(
   lessonCode: string,
-  user: string,
+  guestToken: string,
 ): Promise<Lesson> {
   const response = await http.get<Lesson>(`/lessons/${lessonCode}`, {
-    params: { user },
+    headers: {
+      Authorization: `Bearer ${guestToken}`,
+    },
   });
   return response.data;
 }

--- a/src/features/lesson/api/lesson.api.ts
+++ b/src/features/lesson/api/lesson.api.ts
@@ -1,7 +1,6 @@
 import { http } from '../../../lib/http';
 
 export interface Lesson {
-  lessonCode: string;
   lessonName: string;
   teacherName: string;
 }

--- a/src/features/lesson/api/lesson.api.ts
+++ b/src/features/lesson/api/lesson.api.ts
@@ -1,0 +1,54 @@
+import { http } from '../../../lib/http';
+
+export interface Lesson {
+  lessonCode: string;
+  lessonName: string;
+  teacherName: string;
+}
+
+export interface CreateLessonRequest {
+  teacherName: string;
+  lessonName: string;
+  lessonCode: string;
+  password: string;
+}
+
+export interface AuthenticateLessonRequest {
+  lessonCode: string;
+  password: string;
+}
+
+export interface AuthenticateLessonResponse {
+  lessonCode: string;
+  authenticated: boolean;
+}
+
+export async function createLesson(
+  body: CreateLessonRequest,
+  user: string,
+): Promise<Lesson> {
+  const response = await http.post<Lesson>('/lessons', body, {
+    params: { user },
+  });
+  return response.data;
+}
+
+export async function fetchLesson(
+  lessonCode: string,
+  user: string,
+): Promise<Lesson> {
+  const response = await http.get<Lesson>(`/lessons/${lessonCode}`, {
+    params: { user },
+  });
+  return response.data;
+}
+
+export async function authenticateLesson(
+  body: AuthenticateLessonRequest,
+): Promise<AuthenticateLessonResponse> {
+  const response = await http.post<AuthenticateLessonResponse>(
+    '/lessons/authentications',
+    body,
+  );
+  return response.data;
+}

--- a/src/features/lesson/api/lesson.api.ts
+++ b/src/features/lesson/api/lesson.api.ts
@@ -38,11 +38,11 @@ export async function createLesson(
 
 export async function fetchLesson(
   lessonCode: string,
-  guestToken: string,
+  token: string,
 ): Promise<Lesson> {
   const response = await http.get<Lesson>(`/lessons/${lessonCode}`, {
     headers: {
-      Authorization: `Bearer ${guestToken}`,
+      Authorization: `Bearer ${token}`,
     },
   });
   return response.data;

--- a/src/features/lesson/api/lesson.api.ts
+++ b/src/features/lesson/api/lesson.api.ts
@@ -49,22 +49,6 @@ export async function fetchLesson(
   return response.data;
 }
 
-export async function joinLesson(
-  lessonCode: string,
-  guestToken: string,
-): Promise<Lesson> {
-  const response = await http.post<Lesson>(
-    `/lessons/${lessonCode}/students`,
-    {},
-    {
-      headers: {
-        Authorization: `Bearer ${guestToken}`,
-      },
-    },
-  );
-  return response.data;
-}
-
 export async function authenticateLesson(
   body: AuthenticateLessonRequest,
 ): Promise<AuthenticateLessonResponse> {

--- a/src/features/lesson/api/lesson.api.ts
+++ b/src/features/lesson/api/lesson.api.ts
@@ -21,8 +21,7 @@ export interface AuthenticateLessonRequest {
 }
 
 export interface AuthenticateLessonResponse {
-  lessonCode: string;
-  authenticated: boolean;
+  token: string;
 }
 
 export async function createLesson(
@@ -52,9 +51,12 @@ export async function fetchLesson(
 export async function authenticateLesson(
   body: AuthenticateLessonRequest,
 ): Promise<AuthenticateLessonResponse> {
-  const response = await http.post<AuthenticateLessonResponse>(
-    '/lessons/authentications',
-    body,
-  );
-  return response.data;
+  const response = await http.post('/lessons/authentications', body);
+  const authorizationHeader: string =
+    response.headers.authorization || response.headers.Authorization;
+  if (!authorizationHeader) throw new Error('Authorization header not found');
+  const token = authorizationHeader.startsWith('Bearer ')
+    ? authorizationHeader.slice(7)
+    : authorizationHeader;
+  return { token };
 }

--- a/src/features/lesson/api/lesson.api.ts
+++ b/src/features/lesson/api/lesson.api.ts
@@ -48,6 +48,32 @@ export async function fetchLesson(
   return response.data;
 }
 
+export interface LessonWidgetIds {
+  memo: number[];
+  quiz: number[];
+  vote: number[];
+  attachment: number[];
+}
+
+export interface GetLessonWidgetIdsResponse {
+  widgets: LessonWidgetIds;
+}
+
+export async function fetchLessonWidgetIds(
+  lessonCode: string,
+  token: string,
+): Promise<GetLessonWidgetIdsResponse> {
+  const response = await http.get<GetLessonWidgetIdsResponse>(
+    `/lessons/${lessonCode}/widgets`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+  return response.data;
+}
+
 export async function authenticateLesson(
   body: AuthenticateLessonRequest,
 ): Promise<AuthenticateLessonResponse> {

--- a/src/features/lesson/api/lesson.mock.ts
+++ b/src/features/lesson/api/lesson.mock.ts
@@ -1,0 +1,31 @@
+import { http, HttpResponse } from 'msw';
+
+export const lessonHandlers = [
+  http.get('/lessons/:lessonCode', ({ params }) => {
+    return HttpResponse.json({
+      lessonCode: String(params.lessonCode),
+      lessonName: '샘플 수업',
+      teacherName: '홍길동',
+    });
+  }),
+
+  http.post('/lessons', async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json(
+      {
+        lessonCode: body.lessonCode,
+        lessonName: body.lessonName,
+        teacherName: body.teacherName,
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.post('/lessons/authentications', async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json({
+      lessonCode: body.lessonCode,
+      authenticated: true,
+    });
+  }),
+];

--- a/src/features/lesson/api/lesson.mock.ts
+++ b/src/features/lesson/api/lesson.mock.ts
@@ -1,7 +1,23 @@
 import { http, HttpResponse } from 'msw';
 
+function checkAuthorization(request: Request): boolean {
+  const authorization = request.headers.get('Authorization');
+  return !!authorization && authorization.startsWith('Bearer ');
+}
+
 export const lessonHandlers = [
-  http.get('/lessons/:lessonCode', ({ params }) => {
+  http.get('/lessons/:lessonCode', ({ params, request }) => {
+    if (!checkAuthorization(request)) {
+      return HttpResponse.json(
+        {
+          code: 'USER_UI_001',
+          message: '인증 정보가 필요한 요청입니다.',
+          detail: null,
+        },
+        { status: 401 },
+      );
+    }
+
     return HttpResponse.json({
       lessonCode: String(params.lessonCode),
       lessonName: '샘플 수업',
@@ -10,6 +26,17 @@ export const lessonHandlers = [
   }),
 
   http.post('/lessons', async ({ request }) => {
+    if (!checkAuthorization(request)) {
+      return HttpResponse.json(
+        {
+          code: 'USER_UI_001',
+          message: '인증 정보가 필요한 요청입니다.',
+          detail: null,
+        },
+        { status: 401 },
+      );
+    }
+
     const body = (await request.json()) as Record<string, unknown>;
     return HttpResponse.json(
       {
@@ -22,6 +49,17 @@ export const lessonHandlers = [
   }),
 
   http.post('/lessons/authentications', async ({ request }) => {
+    if (!checkAuthorization(request)) {
+      return HttpResponse.json(
+        {
+          code: 'USER_UI_001',
+          message: '인증 정보가 필요한 요청입니다.',
+          detail: null,
+        },
+        { status: 401 },
+      );
+    }
+
     const body = (await request.json()) as Record<string, unknown>;
     return HttpResponse.json({
       lessonCode: body.lessonCode,

--- a/src/features/lesson/api/lesson.queries.ts
+++ b/src/features/lesson/api/lesson.queries.ts
@@ -7,19 +7,24 @@ import {
   type AuthenticateLessonRequest,
 } from './lesson.api';
 
-export function useLessonQuery(lessonCode: string, user: string) {
+export function useLessonQuery(lessonCode: string, guestToken: string) {
   return useQuery({
-    queryKey: ['lesson', 'detail', lessonCode, user],
-    queryFn: () => fetchLesson(lessonCode, user),
-    enabled: !!lessonCode && !!user,
+    queryKey: ['lesson', 'detail', lessonCode, guestToken],
+    queryFn: () => fetchLesson(lessonCode, guestToken),
+    enabled: !!lessonCode && !!guestToken,
   });
 }
 
 export function useCreateLessonMutation() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ body, user }: { body: CreateLessonRequest; user: string }) =>
-      createLesson(body, user),
+    mutationFn: ({
+      body,
+      guestToken,
+    }: {
+      body: CreateLessonRequest;
+      guestToken: string;
+    }) => createLesson(body, guestToken),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['lesson'] });
     },

--- a/src/features/lesson/api/lesson.queries.ts
+++ b/src/features/lesson/api/lesson.queries.ts
@@ -1,0 +1,33 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  fetchLesson,
+  createLesson,
+  authenticateLesson,
+  type CreateLessonRequest,
+  type AuthenticateLessonRequest,
+} from './lesson.api';
+
+export function useLessonQuery(lessonCode: string, user: string) {
+  return useQuery({
+    queryKey: ['lesson', 'detail', lessonCode, user],
+    queryFn: () => fetchLesson(lessonCode, user),
+    enabled: !!lessonCode && !!user,
+  });
+}
+
+export function useCreateLessonMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ body, user }: { body: CreateLessonRequest; user: string }) =>
+      createLesson(body, user),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['lesson'] });
+    },
+  });
+}
+
+export function useAuthenticateLessonMutation() {
+  return useMutation({
+    mutationFn: (body: AuthenticateLessonRequest) => authenticateLesson(body),
+  });
+}

--- a/src/features/lesson/api/lesson.queries.ts
+++ b/src/features/lesson/api/lesson.queries.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   fetchLesson,
+  fetchLessonWidgetIds,
   createLesson,
   authenticateLesson,
   type CreateLessonRequest,
@@ -12,6 +13,14 @@ export function useLessonQuery(lessonCode: string, guestToken: string) {
     queryKey: ['lesson', 'detail', lessonCode, guestToken],
     queryFn: () => fetchLesson(lessonCode, guestToken),
     enabled: !!lessonCode && !!guestToken,
+  });
+}
+
+export function useLessonWidgetIdsQuery(lessonCode: string, token: string) {
+  return useQuery({
+    queryKey: ['lesson', 'widgets', lessonCode],
+    queryFn: () => fetchLessonWidgetIds(lessonCode, token),
+    enabled: !!lessonCode && !!token,
   });
 }
 

--- a/src/features/main/components/modal/create-lesson-modal/CreateLessonModal.tsx
+++ b/src/features/main/components/modal/create-lesson-modal/CreateLessonModal.tsx
@@ -14,6 +14,8 @@ interface CreateLessonModalProps {
   isOpen: boolean;
   onClose: () => void;
   lessonCode: string;
+  isLoading?: boolean;
+  error?: string | null;
   onSubmit?: (payload: {
     lessonName: string;
     teacherName: string;
@@ -26,6 +28,8 @@ function CreateLessonModal({
   isOpen,
   onClose,
   lessonCode,
+  isLoading = false,
+  error = null,
   onSubmit,
 }: CreateLessonModalProps) {
   const lessonNameInput = useFormInput({ validator: validateLessonName });
@@ -116,8 +120,14 @@ function CreateLessonModal({
             수업 코드 분실 시 수업 참여에 어려움이 발생할 수 있습니다!
           </span>
         </div>
-        <Button type="submit" variant="blue" size="xl" disabled={!isValid}>
-          수업 시작하기
+        {error && <span className="label-regular text-red-500">{error}</span>}
+        <Button
+          type="submit"
+          variant="blue"
+          size="xl"
+          disabled={!isValid || isLoading}
+        >
+          {isLoading ? '수업 생성 중...' : '수업 시작하기'}
         </Button>
       </form>
     </Modal>

--- a/src/features/main/components/ui/entrance-form/EntranceForm.tsx
+++ b/src/features/main/components/ui/entrance-form/EntranceForm.tsx
@@ -47,7 +47,8 @@ function EntranceForm({
           type="submit"
           shape="square"
           iconName="add"
-          className="h-12 w-[75px] bg-blue-300"
+          className="h-12 w-[75px] bg-blue-300 hover:bg-blue-200"
+          iconClassName="invert"
           disabled={!validateLessonCode(code)}
         />
       </div>

--- a/src/features/main/components/ui/entrance-section/EntranceSection.tsx
+++ b/src/features/main/components/ui/entrance-section/EntranceSection.tsx
@@ -26,10 +26,12 @@ function EntranceSection({ onJoin, onFind, onCreate }: EntranceSectionProps) {
           onSubmitCode={onFind}
         />
         <IconButton
-          className="bg-blue-300 text-black-0 w-full h-15 rounded-2xl"
+          className="bg-blue-300 hover:bg-blue-200 w-full h-15 rounded-2xl"
           shape="square"
           iconName="add"
+          iconClassName="invert"
           label="새 수업 만들기"
+          labelClassName="text-black-0"
           onClick={onCreate}
         />
       </div>

--- a/src/features/main/components/ui/entrance-section/EntranceSection.tsx
+++ b/src/features/main/components/ui/entrance-section/EntranceSection.tsx
@@ -26,7 +26,7 @@ function EntranceSection({ onJoin, onFind, onCreate }: EntranceSectionProps) {
           onSubmitCode={onFind}
         />
         <IconButton
-          className="bg-blue-300 text-black-0 w-full h-15"
+          className="bg-blue-300 text-black-0 w-full h-15 rounded-2xl"
           shape="square"
           iconName="add"
           label="새 수업 만들기"

--- a/src/features/main/components/ui/hero-section/HeroSection.tsx
+++ b/src/features/main/components/ui/hero-section/HeroSection.tsx
@@ -15,11 +15,11 @@ function HeroSection({ className }: HeroSectionProps) {
   return (
     <section className={cn('flex flex-col gap-5', className)}>
       <header className="flex flex-col gap-5">
-        <h1 className="h1-bold text-black-500">
+        <h1 className="h1-bold text-black-500 whitespace-nowrap">
           수업 도구를 한 화면에,
           <span className="text-blue-300 "> Composite</span>
         </h1>
-        <p className="h3-semibold text-black-500">
+        <p className="h3-semibold text-black-500 whitespace-nowrap">
           흩어진 수업 도구, 이제 하나로 연결하세요.
         </p>
         <div className="flex flex-col body-regular text-black-500 gap-3.5">
@@ -37,7 +37,7 @@ function HeroSection({ className }: HeroSectionProps) {
           </div>
         </div>
       </header>
-      <ul className="flex flex-row items-center justify-between">
+      <ul className="flex flex-row items-center gap-3.5">
         {HERO_BADGES.map((badge) => (
           <li key={badge.id}>
             <HeroBadge badgeName={badge.name} label={badge.label} />

--- a/src/features/main/components/ui/widget-description-card/WidgetDescriptionCard.tsx
+++ b/src/features/main/components/ui/widget-description-card/WidgetDescriptionCard.tsx
@@ -6,7 +6,7 @@ import WidgetIcon from '@/shared/components/ui/widget-icon/WidgetIcon';
 type IconName = 'info' | 'note' | 'file' | 'quiz' | 'vote' | 'question';
 
 const cardVariants = cva(
-  'flex flex-col w-70 p-6 pb-12 gap-4 bg-white rounded-2xl border-2 transition-all overflow-hidden text-left',
+  'flex flex-col p-6 gap-4 bg-white rounded-2xl border-2 transition-all text-left aspect-[2/1]',
   {
     variants: {
       iconName: {
@@ -114,7 +114,11 @@ function WidgetDescriptionCard({
     <button
       type="button"
       onClick={onClick}
-      className={cn(cardVariants({ iconName, isSelected }), 'cursor-pointer')}
+      className={cn(
+        cardVariants({ iconName, isSelected }),
+        'cursor-pointer',
+        className,
+      )}
       {...props}
     >
       <div className="flex items-center gap-2">
@@ -122,9 +126,9 @@ function WidgetDescriptionCard({
         <span className="body-semibold text-black-500">{title}</span>
       </div>
 
-      <div className="overflow-y-auto">
-        <p className="description-regular text-black-300">{description}</p>
-      </div>
+      <p className="description-regular leading-[normal] text-black-300">
+        {description}
+      </p>
     </button>
   );
 }

--- a/src/features/memo/api/memo.api.ts
+++ b/src/features/memo/api/memo.api.ts
@@ -1,0 +1,21 @@
+import { http } from '../../../lib/http';
+
+export interface MemoWidget {
+  id: number;
+  widgetId: number;
+  title: string;
+  content: string;
+  updatedTime: string;
+}
+
+export async function fetchMemoWidget(
+  memoWidgetId: number,
+  token: string,
+): Promise<MemoWidget> {
+  const response = await http.get<MemoWidget>(`/memoWidgets/${memoWidgetId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return response.data;
+}

--- a/src/features/memo/api/memo.queries.ts
+++ b/src/features/memo/api/memo.queries.ts
@@ -1,0 +1,12 @@
+import { useQueries } from '@tanstack/react-query';
+import { fetchMemoWidget } from './memo.api';
+
+export function useMemoWidgetsQuery(memoWidgetIds: number[], token: string) {
+  return useQueries({
+    queries: memoWidgetIds.map((id) => ({
+      queryKey: ['memoWidget', id],
+      queryFn: () => fetchMemoWidget(id, token),
+      enabled: !!token,
+    })),
+  });
+}

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+export const http = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+});

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -3,3 +3,11 @@ import axios from 'axios';
 export const http = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
 });
+
+export function setAuthToken(token: string): void {
+  http.defaults.headers.common.Authorization = `Bearer ${token}`;
+}
+
+export function clearAuthToken(): void {
+  delete http.defaults.headers.common.Authorization;
+}

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,24 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from './lib/queryClient';
 import './index.css';
 import App from './app/App';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+async function enableMocking(): Promise<void> {
+  if (!import.meta.env.DEV) {
+    return;
+  }
+  const { worker } = await import('./mocks/browser');
+  await worker.start({ onUnhandledRequest: 'bypass' });
+}
+
+enableMocking().then(() => {
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </StrictMode>,
+  );
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import './index.css';
 import App from './app/App';
 
 async function enableMocking(): Promise<void> {
-  if (!import.meta.env.DEV) {
+  if (!import.meta.env.DEV || import.meta.env.VITE_MSW_ENABLED === 'false') {
     return;
   }
   const { worker } = await import('./mocks/browser');

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,3 +1,4 @@
 import { userHandlers } from '../features/example/api/example.mock.ts';
+import { lessonHandlers } from '../features/lesson/api/lesson.mock';
 
-export const handlers = [...userHandlers];
+export const handlers = [...userHandlers, ...lessonHandlers];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,4 +1,5 @@
 import { userHandlers } from '../features/example/api/example.mock.ts';
 import { lessonHandlers } from '../features/lesson/api/lesson.mock';
+import { guestHandlers } from '../features/guest/api/guest.mock';
 
-export const handlers = [...userHandlers, ...lessonHandlers];
+export const handlers = [...userHandlers, ...lessonHandlers, ...guestHandlers];

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -1,5 +1,20 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import type { DragEndEvent } from '@dnd-kit/core';
+import {
+  SortableContext,
+  useSortable,
+  arrayMove,
+  rectSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import type { WidgetName } from '@/shared/types/widget.type';
 import type { LectureMaterial } from '@/features/lecture-materials/types';
 import type { VoteSelectionItem } from '@/features/vote/ui/blocks/SelectionList';
@@ -39,6 +54,38 @@ type SimpleWidget = {
 
 type DashboardWidget = QuizWidget | VoteWidget | SimpleWidget;
 
+interface SortableWidgetProps {
+  widget: DashboardWidget;
+  children: React.ReactNode;
+}
+
+function SortableWidget({ widget, children }: SortableWidgetProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: widget.id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+      }}
+      className="mb-5 break-inside-avoid cursor-grab active:cursor-grabbing"
+      {...attributes}
+      {...listeners}
+    >
+      {children}
+    </div>
+  );
+}
+
 function DashBoardPage() {
   const { lessonName = '', teacherName = '' } = useParams<{
     lessonName: string;
@@ -49,6 +96,10 @@ function DashBoardPage() {
     null,
   );
   const [widgets, setWidgets] = useState<DashboardWidget[]>([]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  );
 
   function handleOpenAddModal() {
     setIsAddModalOpen(true);
@@ -121,12 +172,22 @@ function DashBoardPage() {
     );
   }
 
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    setWidgets((previous) => {
+      const oldIndex = previous.findIndex((widget) => widget.id === active.id);
+      const newIndex = previous.findIndex((widget) => widget.id === over.id);
+      return arrayMove(previous, oldIndex, newIndex);
+    });
+  }
+
   function renderWidget(widget: DashboardWidget) {
     switch (widget.type) {
       case 'quiz':
         return (
           <QuizTeacher
-            key={widget.id}
             question={widget.question}
             choices={widget.choices}
             correctIndex={widget.correctAnswerIndex}
@@ -138,7 +199,6 @@ function DashBoardPage() {
       case 'vote':
         return (
           <VoteTeacher
-            key={widget.id}
             title={widget.title}
             description={widget.description}
             selections={widget.selections}
@@ -148,18 +208,16 @@ function DashBoardPage() {
       case 'question':
         return (
           <QuestionTeacher
-            key={widget.id}
             questions={[]}
             currentPage={1}
             onPageChange={() => {}}
           />
         );
       case 'note':
-        return <MemoTeacher key={widget.id} />;
+        return <MemoTeacher />;
       case 'file':
         return (
           <LectureMaterialsTeacher
-            key={widget.id}
             materials={[] as LectureMaterial[]}
             onUpload={() => {}}
             onDownload={() => {}}
@@ -189,13 +247,24 @@ function DashBoardPage() {
             <p className="body-medium text-black-200">위젯을 생성해주세요.</p>
           </div>
         ) : (
-          <div className="columns-1 gap-5 md:columns-2 lg:columns-3 xl:columns-4">
-            {widgets.map((widget) => (
-              <div key={widget.id} className="mb-5 break-inside-avoid">
-                {renderWidget(widget)}
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={widgets.map((widget) => widget.id)}
+              strategy={rectSortingStrategy}
+            >
+              <div className="columns-1 gap-5 md:columns-2 lg:columns-3 xl:columns-4">
+                {widgets.map((widget) => (
+                  <SortableWidget key={widget.id} widget={widget}>
+                    {renderWidget(widget)}
+                  </SortableWidget>
+                ))}
               </div>
-            ))}
-          </div>
+            </SortableContext>
+          </DndContext>
         )}
       </div>
       <AddWidgetModal

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -236,11 +236,7 @@ function DashBoardPage() {
 
   return (
     <div className="w-full">
-      <SiteHeader
-        entryCode={lessonCode}
-        dashboardUrl={`/dashboard/${lessonCode}/${lessonName}/${teacherName}`}
-        participantCount={0}
-      />
+      <SiteHeader entryCode={lessonCode} participantCount={0} />
       <DashboardHeader
         lessonName={lessonName}
         teacherName={teacherName}

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -87,7 +87,12 @@ function SortableWidget({ widget, children }: SortableWidgetProps) {
 }
 
 function DashBoardPage() {
-  const { lessonName = '', teacherName = '' } = useParams<{
+  const {
+    lessonCode = '',
+    lessonName = '',
+    teacherName = '',
+  } = useParams<{
+    lessonCode: string;
     lessonName: string;
     teacherName: string;
   }>();
@@ -232,8 +237,8 @@ function DashBoardPage() {
   return (
     <div className="w-full">
       <SiteHeader
-        entryCode={lessonName}
-        dashboardUrl={`/dashboard/${lessonName}/${teacherName}`}
+        entryCode={lessonCode}
+        dashboardUrl={`/dashboard/${lessonCode}/${lessonName}/${teacherName}`}
         participantCount={0}
       />
       <DashboardHeader

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import type { WidgetName } from '@/shared/types/widget.type';
 import type { LectureMaterial } from '@/features/lecture-materials/types';
 import type { VoteSelectionItem } from '@/features/vote/ui/blocks/SelectionList';
+import SiteHeader from '@/shared/components/widget/dashboard-header/DashboardHeader';
 import DashboardHeader from '@/features/dashboard/ui/dashboard-header/DashboardHeader';
 import AddWidgetModal from '@/features/dashboard/modal/add-widget-modal/AddWidgetModal';
 import QuizCreate, { type QuizCreateData } from '@/features/quiz/ui/QuizCreate';
@@ -172,6 +173,11 @@ function DashBoardPage() {
 
   return (
     <div className="w-full">
+      <SiteHeader
+        entryCode={lessonName}
+        dashboardUrl={`/dashboard/${lessonName}/${teacherName}`}
+        participantCount={0}
+      />
       <DashboardHeader
         lessonName={lessonName}
         teacherName={teacherName}

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import {
   DndContext,
@@ -18,6 +18,9 @@ import { CSS } from '@dnd-kit/utilities';
 import type { WidgetName } from '@/shared/types/widget.type';
 import type { LectureMaterial } from '@/features/lecture-materials/types';
 import type { VoteSelectionItem } from '@/features/vote/ui/blocks/SelectionList';
+import { useLessonWidgetIdsQuery } from '@/features/lesson/api/lesson.queries';
+import { useMemoWidgetsQuery } from '@/features/memo/api/memo.queries';
+import type { MemoWidget } from '@/features/memo/api/memo.api';
 import SiteHeader from '@/shared/components/widget/dashboard-header/DashboardHeader';
 import DashboardHeader from '@/features/dashboard/ui/dashboard-header/DashboardHeader';
 import AddWidgetModal from '@/features/dashboard/modal/add-widget-modal/AddWidgetModal';
@@ -47,12 +50,20 @@ type VoteWidget = {
   options: string[];
 };
 
+type NoteWidget = {
+  type: 'note';
+  id: string;
+  memoWidgetId?: number;
+  title: string;
+  content: string;
+};
+
 type SimpleWidget = {
-  type: 'question' | 'note' | 'file';
+  type: 'question' | 'file';
   id: string;
 };
 
-type DashboardWidget = QuizWidget | VoteWidget | SimpleWidget;
+type DashboardWidget = QuizWidget | VoteWidget | NoteWidget | SimpleWidget;
 
 interface SortableWidgetProps {
   widget: DashboardWidget;
@@ -101,6 +112,38 @@ function DashBoardPage() {
     null,
   );
   const [widgets, setWidgets] = useState<DashboardWidget[]>([]);
+  const hasInitializedRef = useRef(false);
+
+  const authToken = localStorage.getItem('authToken') ?? '';
+  const { data: widgetIdsData } = useLessonWidgetIdsQuery(
+    lessonCode,
+    authToken,
+  );
+  const memoWidgetIds = useMemo(
+    () => widgetIdsData?.widgets.memo ?? [],
+    [widgetIdsData],
+  );
+  const memoWidgetQueries = useMemoWidgetsQuery(memoWidgetIds, authToken);
+
+  useEffect(() => {
+    if (hasInitializedRef.current) return;
+    if (memoWidgetIds.length === 0) return;
+    if (!memoWidgetQueries.every((query) => query.isSuccess)) return;
+
+    hasInitializedRef.current = true;
+    setWidgets(
+      memoWidgetQueries
+        .map((query) => query.data)
+        .filter((data): data is MemoWidget => data !== undefined)
+        .map((data) => ({
+          type: 'note' as const,
+          id: String(data.id),
+          memoWidgetId: data.id,
+          title: data.title,
+          content: data.content,
+        })),
+    );
+  }, [memoWidgetIds, memoWidgetQueries]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -118,6 +161,13 @@ function DashBoardPage() {
     setIsAddModalOpen(false);
     if (id === 'quiz' || id === 'vote') {
       setActiveCreateModal(id);
+      return;
+    }
+    if (id === 'note') {
+      setWidgets((previous) => [
+        ...previous,
+        { type: 'note', id: crypto.randomUUID(), title: '', content: '' },
+      ]);
       return;
     }
     setWidgets((previous) => [
@@ -219,7 +269,12 @@ function DashBoardPage() {
           />
         );
       case 'note':
-        return <MemoTeacher />;
+        return (
+          <MemoTeacher
+            initialTitle={widget.title}
+            initialMemo={widget.content}
+          />
+        );
       case 'file':
         return (
           <LectureMaterialsTeacher

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -183,8 +183,20 @@ function DashBoardPage() {
         teacherName={teacherName}
         onOpenModal={handleOpenAddModal}
       />
-      <div className="flex flex-wrap gap-5 p-10">
-        {widgets.map(renderWidget)}
+      <div className="px-30 py-6">
+        {widgets.length === 0 ? (
+          <div className="flex w-full items-center justify-center py-20">
+            <p className="body-medium text-black-200">위젯을 생성해주세요.</p>
+          </div>
+        ) : (
+          <div className="columns-1 gap-5 md:columns-2 lg:columns-3 xl:columns-4">
+            {widgets.map((widget) => (
+              <div key={widget.id} className="mb-5 break-inside-avoid">
+                {renderWidget(widget)}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
       <AddWidgetModal
         isOpen={isAddModalOpen}

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import DashboardHeader from '@/features/dashboard/ui/dashboard-header/DashboardHeader';
 import AddWidgetModal from '@/features/dashboard/modal/add-widget-modal/AddWidgetModal';
 
-interface DashBoardPageProps {
-  lessonName: string;
-  teacherName: string;
-}
-
-function DashBoardPage({ lessonName, teacherName }: DashBoardPageProps) {
+function DashBoardPage() {
+  const { lessonName = '', teacherName = '' } = useParams<{
+    lessonName: string;
+    teacherName: string;
+  }>();
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const handleCloseAddModal = () => {
     setIsAddModalOpen(false);

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -1,7 +1,42 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
+import type { WidgetName } from '@/shared/types/widget.type';
+import type { LectureMaterial } from '@/features/lecture-materials/types';
+import type { VoteSelectionItem } from '@/features/vote/ui/blocks/SelectionList';
 import DashboardHeader from '@/features/dashboard/ui/dashboard-header/DashboardHeader';
 import AddWidgetModal from '@/features/dashboard/modal/add-widget-modal/AddWidgetModal';
+import QuizCreate, { type QuizCreateData } from '@/features/quiz/ui/QuizCreate';
+import VoteCreate from '@/features/vote/ui/VoteCreate';
+import QuizTeacher from '@/features/quiz/ui/QuizTeacher';
+import VoteTeacher from '@/features/vote/ui/VoteTeacher';
+import QuestionTeacher from '@/features/question/ui/QuestionTeacher';
+import MemoTeacher from '@/features/memo/ui/MemoTeacher';
+import LectureMaterialsTeacher from '@/features/lecture-materials/ui/LectureMaterialsTeacher';
+
+type QuizWidget = {
+  type: 'quiz';
+  id: string;
+  question: string;
+  choices: string[];
+  correctAnswerIndex: number;
+  isEnded: boolean;
+};
+
+type VoteWidget = {
+  type: 'vote';
+  id: string;
+  title: string;
+  description: string;
+  selections: VoteSelectionItem[];
+  options: string[];
+};
+
+type SimpleWidget = {
+  type: 'question' | 'note' | 'file';
+  id: string;
+};
+
+type DashboardWidget = QuizWidget | VoteWidget | SimpleWidget;
 
 function DashBoardPage() {
   const { lessonName = '', teacherName = '' } = useParams<{
@@ -9,12 +44,132 @@ function DashBoardPage() {
     teacherName: string;
   }>();
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
-  const handleCloseAddModal = () => {
-    setIsAddModalOpen(false);
-  };
-  const handleOpenAddModal = () => {
+  const [activeCreateModal, setActiveCreateModal] = useState<WidgetName | null>(
+    null,
+  );
+  const [widgets, setWidgets] = useState<DashboardWidget[]>([]);
+
+  function handleOpenAddModal() {
     setIsAddModalOpen(true);
-  };
+  }
+
+  function handleCloseAddModal() {
+    setIsAddModalOpen(false);
+  }
+
+  function handleSelectWidget(id: WidgetName) {
+    setIsAddModalOpen(false);
+    if (id === 'quiz' || id === 'vote') {
+      setActiveCreateModal(id);
+      return;
+    }
+    setWidgets((previous) => [
+      ...previous,
+      { type: id, id: crypto.randomUUID() },
+    ]);
+  }
+
+  function handleCloseCreateModal() {
+    setActiveCreateModal(null);
+  }
+
+  function handleQuizSubmit(data: QuizCreateData) {
+    setWidgets((previous) => [
+      ...previous,
+      {
+        type: 'quiz',
+        id: crypto.randomUUID(),
+        question: data.question,
+        choices: data.choices,
+        correctAnswerIndex: data.correctAnswerIndex,
+        isEnded: false,
+      },
+    ]);
+    setActiveCreateModal(null);
+  }
+
+  function handleVoteSubmit(data: {
+    title: string;
+    description: string;
+    selections: VoteSelectionItem[];
+    options: { id: string; label: string; enabled: boolean }[];
+  }) {
+    setWidgets((previous) => [
+      ...previous,
+      {
+        type: 'vote',
+        id: crypto.randomUUID(),
+        title: data.title,
+        description: data.description,
+        selections: data.selections,
+        options: data.options
+          .filter((option) => option.enabled)
+          .map((option) => option.label),
+      },
+    ]);
+    setActiveCreateModal(null);
+  }
+
+  function handleQuizEnd(widgetId: string) {
+    setWidgets((previous) =>
+      previous.map((widget) =>
+        widget.id === widgetId && widget.type === 'quiz'
+          ? { ...widget, isEnded: true }
+          : widget,
+      ),
+    );
+  }
+
+  function renderWidget(widget: DashboardWidget) {
+    switch (widget.type) {
+      case 'quiz':
+        return (
+          <QuizTeacher
+            key={widget.id}
+            question={widget.question}
+            choices={widget.choices}
+            correctIndex={widget.correctAnswerIndex}
+            participantCount={0}
+            isEnded={widget.isEnded}
+            onEnd={() => handleQuizEnd(widget.id)}
+          />
+        );
+      case 'vote':
+        return (
+          <VoteTeacher
+            key={widget.id}
+            title={widget.title}
+            description={widget.description}
+            selections={widget.selections}
+            options={widget.options}
+          />
+        );
+      case 'question':
+        return (
+          <QuestionTeacher
+            key={widget.id}
+            questions={[]}
+            currentPage={1}
+            onPageChange={() => {}}
+          />
+        );
+      case 'note':
+        return <MemoTeacher key={widget.id} />;
+      case 'file':
+        return (
+          <LectureMaterialsTeacher
+            key={widget.id}
+            materials={[] as LectureMaterial[]}
+            onUpload={() => {}}
+            onDownload={() => {}}
+            onDelete={() => {}}
+          />
+        );
+      default:
+        return null;
+    }
+  }
+
   return (
     <div className="w-full">
       <DashboardHeader
@@ -22,7 +177,24 @@ function DashBoardPage() {
         teacherName={teacherName}
         onOpenModal={handleOpenAddModal}
       />
-      <AddWidgetModal isOpen={isAddModalOpen} onClose={handleCloseAddModal} />
+      <div className="flex flex-wrap gap-5 p-10">
+        {widgets.map(renderWidget)}
+      </div>
+      <AddWidgetModal
+        isOpen={isAddModalOpen}
+        onClose={handleCloseAddModal}
+        onSelectWidget={handleSelectWidget}
+      />
+      <QuizCreate
+        isOpen={activeCreateModal === 'quiz'}
+        onClose={handleCloseCreateModal}
+        onSubmit={handleQuizSubmit}
+      />
+      <VoteCreate
+        isOpen={activeCreateModal === 'vote'}
+        onCancel={handleCloseCreateModal}
+        onSubmit={handleVoteSubmit}
+      />
     </div>
   );
 }

--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -11,6 +11,7 @@ import JoinLessonModal from '@/features/main/components/modal/join-lesson-modal/
 import FindLessonModal from '@/features/main/components/modal/find-lesson-modal/FindLessonModal';
 import CreateLessonModal from '@/features/main/components/modal/create-lesson-modal/CreateLessonModal';
 import { useCreateLessonMutation } from '@/features/lesson/api/lesson.queries';
+import { getGuestToken } from '@/features/guest/api/guest.api';
 
 type SelectedId = 'note' | 'file' | 'quiz' | 'vote' | 'question';
 type ModalType = 'join' | 'find' | 'create' | null;
@@ -24,16 +25,6 @@ function generateLessonCode(): string {
   return code;
 }
 
-function getOrCreateUserId(): string {
-  const key = 'composite_user_id';
-  let userId = localStorage.getItem(key);
-  if (!userId) {
-    userId = `user_${Date.now()}_${Math.random().toString(36).substring(7)}`;
-    localStorage.setItem(key, userId);
-  }
-  return userId;
-}
-
 export default function MainPage() {
   const navigate = useNavigate();
   const [selectedWidgetId, setSelectedWidgetId] =
@@ -43,7 +34,6 @@ export default function MainPage() {
   const [submittedJoinCode, setSubmittedJoinCode] = useState('');
   const [submittedFindCode, setSubmittedFindCode] = useState('');
   const [lessonCode, setLessonCode] = useState<string>('');
-  const [userId] = useState(() => getOrCreateUserId());
 
   const createLessonMutation = useCreateLessonMutation();
 
@@ -70,21 +60,28 @@ export default function MainPage() {
     setOpenedModal('create');
   };
 
-  const handleCreateSubmit = (payload: {
+  const handleCreateSubmit = async (payload: {
     lessonName: string;
     teacherName: string;
     password: string;
     lessonCode: string;
   }) => {
-    createLessonMutation.mutate({
-      body: {
-        teacherName: payload.teacherName,
-        lessonName: payload.lessonName,
-        lessonCode: payload.lessonCode,
-        password: payload.password,
-      },
-      user: userId,
-    });
+    try {
+      const guestCredentialsResponse = await getGuestToken({
+        name: payload.teacherName,
+      });
+      createLessonMutation.mutate({
+        body: {
+          teacherName: payload.teacherName,
+          lessonName: payload.lessonName,
+          lessonCode: payload.lessonCode,
+          password: payload.password,
+        },
+        guestToken: guestCredentialsResponse.token,
+      });
+    } catch {
+      // eslint-disable-next-line no-empty
+    }
   };
 
   return (

--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -88,6 +88,7 @@ export default function MainPage() {
       const guestCredentialsResponse = await getGuestToken({
         name: payload.studentName,
       });
+      localStorage.setItem('authToken', guestCredentialsResponse.token);
       const lesson = await fetchLesson(
         payload.lessonCode,
         guestCredentialsResponse.token,
@@ -110,6 +111,7 @@ export default function MainPage() {
         password: payload.password,
       });
       localStorage.setItem('lessonAuthToken', authResponse.token);
+      localStorage.setItem('authToken', authResponse.token);
       const lesson = await fetchLesson(payload.lessonCode, authResponse.token);
       navigate(
         `/dashboard/${payload.lessonCode}/${lesson.lessonName}/${lesson.teacherName}`,
@@ -129,6 +131,7 @@ export default function MainPage() {
       const guestCredentialsResponse = await getGuestToken({
         name: payload.teacherName,
       });
+      localStorage.setItem('authToken', guestCredentialsResponse.token);
       createLessonMutation.mutate({
         body: {
           teacherName: payload.teacherName,

--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import DashboardHeader from '@/shared/components/widget/dashboard-header/DashboardHeader';
 import { WIDGET_DATA } from '@/features/main/data/widgetData';
@@ -10,9 +10,29 @@ import VideoSection from '@/features/main/components/ui/video-section/VideoSecti
 import JoinLessonModal from '@/features/main/components/modal/join-lesson-modal/JoinLessonModal';
 import FindLessonModal from '@/features/main/components/modal/find-lesson-modal/FindLessonModal';
 import CreateLessonModal from '@/features/main/components/modal/create-lesson-modal/CreateLessonModal';
+import { useCreateLessonMutation } from '@/features/lesson/api/lesson.queries';
 
 type SelectedId = 'note' | 'file' | 'quiz' | 'vote' | 'question';
 type ModalType = 'join' | 'find' | 'create' | null;
+
+function generateLessonCode(): string {
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let code = '';
+  for (let i = 0; i < 8; i += 1) {
+    code += characters.charAt(Math.floor(Math.random() * characters.length));
+  }
+  return code;
+}
+
+function getOrCreateUserId(): string {
+  const key = 'composite_user_id';
+  let userId = localStorage.getItem(key);
+  if (!userId) {
+    userId = `user_${Date.now()}_${Math.random().toString(36).substring(7)}`;
+    localStorage.setItem(key, userId);
+  }
+  return userId;
+}
 
 export default function MainPage() {
   const navigate = useNavigate();
@@ -23,6 +43,16 @@ export default function MainPage() {
   const [submittedJoinCode, setSubmittedJoinCode] = useState('');
   const [submittedFindCode, setSubmittedFindCode] = useState('');
   const [lessonCode, setLessonCode] = useState<string>('');
+  const [userId] = useState(() => getOrCreateUserId());
+
+  const createLessonMutation = useCreateLessonMutation();
+
+  useEffect(() => {
+    if (createLessonMutation.isSuccess && createLessonMutation.data) {
+      const lesson = createLessonMutation.data;
+      navigate(`/dashboard/${lesson.lessonName}/${lesson.teacherName}`);
+    }
+  }, [createLessonMutation.isSuccess, createLessonMutation.data, navigate]);
 
   const handleCloseModal = () => {
     setOpenedModal(null);
@@ -36,7 +66,7 @@ export default function MainPage() {
     setOpenedModal('find');
   };
   const handleCreateCode = () => {
-    setLessonCode('ABCD1234');
+    setLessonCode(generateLessonCode());
     setOpenedModal('create');
   };
 
@@ -46,7 +76,15 @@ export default function MainPage() {
     password: string;
     lessonCode: string;
   }) => {
-    navigate(`/dashboard/${payload.lessonName}/${payload.teacherName}`);
+    createLessonMutation.mutate({
+      body: {
+        teacherName: payload.teacherName,
+        lessonName: payload.lessonName,
+        lessonCode: payload.lessonCode,
+        password: payload.password,
+      },
+      user: userId,
+    });
   };
 
   return (
@@ -109,6 +147,8 @@ export default function MainPage() {
             isOpen
             onClose={handleCloseModal}
             lessonCode={lessonCode}
+            isLoading={createLessonMutation.isPending}
+            error={createLessonMutation.error?.message || null}
             onSubmit={handleCreateSubmit}
           />
         )}

--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -54,14 +54,14 @@ export default function MainPage() {
       <DashboardHeader logoOnly />
       <main className="flex w-full justify-center px-30 py-10">
         <div className="flex flex-col items-center w-full gap-20">
-          <section className="flex w-full h-155 gap-30 justify-between">
-            <div className="flex flex-1">
+          <section className="flex w-full gap-30 justify-between items-stretch">
+            <div className="flex flex-1 min-w-0">
               <VideoSection
                 className="h-full w-full"
                 selectedId={selectedWidgetId}
               />
             </div>
-            <div className="flex flex-col justify-between w-[500px]">
+            <div className="flex flex-col gap-20 w-auto shrink-0">
               <HeroSection />
               <EntranceSection
                 onJoin={handleJoin}
@@ -75,7 +75,7 @@ export default function MainPage() {
               className="flex items-center"
               text="카드를 클릭해 위젯 기능을 미리 확인해보세요"
             />
-            <div className="flex justify-between w-full">
+            <div className="flex gap-9 w-full">
               {WIDGET_DATA.map((widget) => (
                 <WidgetDescriptionCard
                   key={widget.id}
@@ -84,6 +84,7 @@ export default function MainPage() {
                   description={widget.description}
                   isSelected={selectedWidgetId === widget.id}
                   onClick={() => setSelectedWidgetId(widget.id)}
+                  className="flex-1"
                 />
               ))}
             </div>

--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -109,6 +109,7 @@ export default function MainPage() {
         lessonCode: payload.lessonCode,
         password: payload.password,
       });
+      localStorage.setItem('lessonAuthToken', authResponse.token);
       const lesson = await fetchLesson(payload.lessonCode, authResponse.token);
       navigate(
         `/dashboard/${payload.lessonCode}/${lesson.lessonName}/${lesson.teacherName}`,

--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import DashboardHeader from '@/shared/components/widget/dashboard-header/DashboardHeader';
 import { WIDGET_DATA } from '@/features/main/data/widgetData';
 import EntranceSection from '@/features/main/components/ui/entrance-section/EntranceSection';
@@ -28,6 +28,7 @@ function generateLessonCode(): string {
 
 export default function MainPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [selectedWidgetId, setSelectedWidgetId] =
     useState<SelectedId>('question');
   const [openedModal, setOpenedModal] = useState<ModalType>(null);
@@ -37,6 +38,14 @@ export default function MainPage() {
   const [lessonCode, setLessonCode] = useState<string>('');
 
   const createLessonMutation = useCreateLessonMutation();
+
+  useEffect(() => {
+    const lessonCodeParam = searchParams.get('lessonCode');
+    if (lessonCodeParam) {
+      setSubmittedJoinCode(lessonCodeParam);
+      setOpenedModal('join');
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     if (createLessonMutation.isSuccess && createLessonMutation.data) {

--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -11,7 +11,7 @@ import JoinLessonModal from '@/features/main/components/modal/join-lesson-modal/
 import FindLessonModal from '@/features/main/components/modal/find-lesson-modal/FindLessonModal';
 import CreateLessonModal from '@/features/main/components/modal/create-lesson-modal/CreateLessonModal';
 import { useCreateLessonMutation } from '@/features/lesson/api/lesson.queries';
-import { joinLesson } from '@/features/lesson/api/lesson.api';
+import { fetchLesson } from '@/features/lesson/api/lesson.api';
 import { getGuestToken } from '@/features/guest/api/guest.api';
 
 type SelectedId = 'note' | 'file' | 'quiz' | 'vote' | 'question';
@@ -85,7 +85,7 @@ export default function MainPage() {
       const guestCredentialsResponse = await getGuestToken({
         name: payload.studentName,
       });
-      const lesson = await joinLesson(
+      const lesson = await fetchLesson(
         payload.lessonCode,
         guestCredentialsResponse.token,
       );

--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -11,7 +11,10 @@ import JoinLessonModal from '@/features/main/components/modal/join-lesson-modal/
 import FindLessonModal from '@/features/main/components/modal/find-lesson-modal/FindLessonModal';
 import CreateLessonModal from '@/features/main/components/modal/create-lesson-modal/CreateLessonModal';
 import { useCreateLessonMutation } from '@/features/lesson/api/lesson.queries';
-import { fetchLesson } from '@/features/lesson/api/lesson.api';
+import {
+  fetchLesson,
+  authenticateLesson,
+} from '@/features/lesson/api/lesson.api';
 import { getGuestToken } from '@/features/guest/api/guest.api';
 
 type SelectedId = 'note' | 'file' | 'quiz' | 'vote' | 'question';
@@ -89,6 +92,24 @@ export default function MainPage() {
         payload.lessonCode,
         guestCredentialsResponse.token,
       );
+      navigate(
+        `/dashboard/${payload.lessonCode}/${lesson.lessonName}/${lesson.teacherName}`,
+      );
+    } catch {
+      // eslint-disable-next-line no-empty
+    }
+  };
+
+  const handleFindSubmit = async (payload: {
+    password: string;
+    lessonCode: string;
+  }) => {
+    try {
+      const authResponse = await authenticateLesson({
+        lessonCode: payload.lessonCode,
+        password: payload.password,
+      });
+      const lesson = await fetchLesson(payload.lessonCode, authResponse.token);
       navigate(
         `/dashboard/${payload.lessonCode}/${lesson.lessonName}/${lesson.teacherName}`,
       );
@@ -175,6 +196,7 @@ export default function MainPage() {
             lessonCode={submittedFindCode}
             isOpen
             onClose={handleCloseModal}
+            onSubmit={handleFindSubmit}
           />
         )}
         {openedModal === 'create' && (

--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import DashboardHeader from '@/shared/components/widget/dashboard-header/DashboardHeader';
 import { WIDGET_DATA } from '@/features/main/data/widgetData';
 import EntranceSection from '@/features/main/components/ui/entrance-section/EntranceSection';
 import HeroSection from '@/features/main/components/ui/hero-section/HeroSection';
@@ -49,65 +50,68 @@ export default function MainPage() {
   };
 
   return (
-    <main className="flex px-30 py-10">
-      <div className="flex flex-col items-center  w-[1508px] gap-20">
-        <section className="flex w-full h-155 gap-30 justify-between">
-          <div className="flex flex-1">
-            <VideoSection
-              className="h-full w-full"
-              selectedId={selectedWidgetId}
-            />
-          </div>
-          <div className="flex flex-col justify-between w-[500px]">
-            <HeroSection />
-            <EntranceSection
-              onJoin={handleJoin}
-              onFind={handleFind}
-              onCreate={handleCreateCode}
-            />
-          </div>
-        </section>
-        <section className="flex flex-col gap-8 w-full">
-          <SectionDivider
-            className="flex items-center"
-            text="카드를 클릭해 위젯 기능을 미리 확인해보세요"
-          />
-          <div className="flex justify-between w-full">
-            {WIDGET_DATA.map((widget) => (
-              <WidgetDescriptionCard
-                key={widget.id}
-                iconName={widget.id}
-                title={widget.title}
-                description={widget.description}
-                isSelected={selectedWidgetId === widget.id}
-                onClick={() => setSelectedWidgetId(widget.id)}
+    <div className="flex flex-col w-full">
+      <DashboardHeader logoOnly />
+      <main className="flex w-full justify-center px-30 py-10">
+        <div className="flex flex-col items-center w-full gap-20">
+          <section className="flex w-full h-155 gap-30 justify-between">
+            <div className="flex flex-1">
+              <VideoSection
+                className="h-full w-full"
+                selectedId={selectedWidgetId}
               />
-            ))}
-          </div>
-        </section>
-      </div>
-      {openedModal === 'join' && (
-        <JoinLessonModal
-          lessonCode={submittedJoinCode}
-          isOpen
-          onClose={handleCloseModal}
-        />
-      )}
-      {openedModal === 'find' && (
-        <FindLessonModal
-          lessonCode={submittedFindCode}
-          isOpen
-          onClose={handleCloseModal}
-        />
-      )}
-      {openedModal === 'create' && (
-        <CreateLessonModal
-          isOpen
-          onClose={handleCloseModal}
-          lessonCode={lessonCode}
-          onSubmit={handleCreateSubmit}
-        />
-      )}
-    </main>
+            </div>
+            <div className="flex flex-col justify-between w-[500px]">
+              <HeroSection />
+              <EntranceSection
+                onJoin={handleJoin}
+                onFind={handleFind}
+                onCreate={handleCreateCode}
+              />
+            </div>
+          </section>
+          <section className="flex flex-col gap-8 w-full">
+            <SectionDivider
+              className="flex items-center"
+              text="카드를 클릭해 위젯 기능을 미리 확인해보세요"
+            />
+            <div className="flex justify-between w-full">
+              {WIDGET_DATA.map((widget) => (
+                <WidgetDescriptionCard
+                  key={widget.id}
+                  iconName={widget.id}
+                  title={widget.title}
+                  description={widget.description}
+                  isSelected={selectedWidgetId === widget.id}
+                  onClick={() => setSelectedWidgetId(widget.id)}
+                />
+              ))}
+            </div>
+          </section>
+        </div>
+        {openedModal === 'join' && (
+          <JoinLessonModal
+            lessonCode={submittedJoinCode}
+            isOpen
+            onClose={handleCloseModal}
+          />
+        )}
+        {openedModal === 'find' && (
+          <FindLessonModal
+            lessonCode={submittedFindCode}
+            isOpen
+            onClose={handleCloseModal}
+          />
+        )}
+        {openedModal === 'create' && (
+          <CreateLessonModal
+            isOpen
+            onClose={handleCloseModal}
+            lessonCode={lessonCode}
+            onSubmit={handleCreateSubmit}
+          />
+        )}
+      </main>
+    </div>
   );
 }

--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -11,6 +11,7 @@ import JoinLessonModal from '@/features/main/components/modal/join-lesson-modal/
 import FindLessonModal from '@/features/main/components/modal/find-lesson-modal/FindLessonModal';
 import CreateLessonModal from '@/features/main/components/modal/create-lesson-modal/CreateLessonModal';
 import { useCreateLessonMutation } from '@/features/lesson/api/lesson.queries';
+import { joinLesson } from '@/features/lesson/api/lesson.api';
 import { getGuestToken } from '@/features/guest/api/guest.api';
 
 type SelectedId = 'note' | 'file' | 'quiz' | 'vote' | 'question';
@@ -65,6 +66,26 @@ export default function MainPage() {
   const handleCreateCode = () => {
     setLessonCode(generateLessonCode());
     setOpenedModal('create');
+  };
+
+  const handleJoinSubmit = async (payload: {
+    studentName: string;
+    lessonCode: string;
+  }) => {
+    try {
+      const guestCredentialsResponse = await getGuestToken({
+        name: payload.studentName,
+      });
+      const lesson = await joinLesson(
+        payload.lessonCode,
+        guestCredentialsResponse.token,
+      );
+      navigate(
+        `/dashboard/${payload.lessonCode}/${lesson.lessonName}/${lesson.teacherName}`,
+      );
+    } catch {
+      // eslint-disable-next-line no-empty
+    }
   };
 
   const handleCreateSubmit = async (payload: {
@@ -137,6 +158,7 @@ export default function MainPage() {
             lessonCode={submittedJoinCode}
             isOpen
             onClose={handleCloseModal}
+            onSubmit={handleJoinSubmit}
           />
         )}
         {openedModal === 'find' && (

--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { WIDGET_DATA } from '@/features/main/data/widgetData';
 import EntranceSection from '@/features/main/components/ui/entrance-section/EntranceSection';
 import HeroSection from '@/features/main/components/ui/hero-section/HeroSection';
@@ -13,6 +14,7 @@ type SelectedId = 'note' | 'file' | 'quiz' | 'vote' | 'question';
 type ModalType = 'join' | 'find' | 'create' | null;
 
 export default function MainPage() {
+  const navigate = useNavigate();
   const [selectedWidgetId, setSelectedWidgetId] =
     useState<SelectedId>('question');
   const [openedModal, setOpenedModal] = useState<ModalType>(null);
@@ -35,6 +37,15 @@ export default function MainPage() {
   const handleCreateCode = () => {
     setLessonCode('ABCD1234');
     setOpenedModal('create');
+  };
+
+  const handleCreateSubmit = (payload: {
+    lessonName: string;
+    teacherName: string;
+    password: string;
+    lessonCode: string;
+  }) => {
+    navigate(`/dashboard/${payload.lessonName}/${payload.teacherName}`);
   };
 
   return (
@@ -94,6 +105,7 @@ export default function MainPage() {
           isOpen
           onClose={handleCloseModal}
           lessonCode={lessonCode}
+          onSubmit={handleCreateSubmit}
         />
       )}
     </main>

--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -40,9 +40,16 @@ export default function MainPage() {
   useEffect(() => {
     if (createLessonMutation.isSuccess && createLessonMutation.data) {
       const lesson = createLessonMutation.data;
-      navigate(`/dashboard/${lesson.lessonName}/${lesson.teacherName}`);
+      navigate(
+        `/dashboard/${lessonCode}/${lesson.lessonName}/${lesson.teacherName}`,
+      );
     }
-  }, [createLessonMutation.isSuccess, createLessonMutation.data, navigate]);
+  }, [
+    createLessonMutation.isSuccess,
+    createLessonMutation.data,
+    navigate,
+    lessonCode,
+  ]);
 
   const handleCloseModal = () => {
     setOpenedModal(null);

--- a/src/shared/components/ui/icon-button/IconButton.tsx
+++ b/src/shared/components/ui/icon-button/IconButton.tsx
@@ -46,6 +46,7 @@ interface IconButtonProps
   iconName: IconName;
   label?: string;
   labelClassName?: string;
+  iconClassName?: string;
 }
 
 function IconButton({
@@ -55,6 +56,7 @@ function IconButton({
   label,
   className,
   labelClassName,
+  iconClassName,
   ...props
 }: IconButtonProps) {
   return (
@@ -67,7 +69,11 @@ function IconButton({
         className,
       )}
     >
-      <Icon name={iconName} size={iconSizeMap[size ?? 'medium']} />
+      <Icon
+        name={iconName}
+        size={iconSizeMap[size ?? 'medium']}
+        className={iconClassName}
+      />
       {label && (
         <span className={cn('body-medium text-black-500', labelClassName)}>
           {label}

--- a/src/shared/components/ui/modal/Modal.tsx
+++ b/src/shared/components/ui/modal/Modal.tsx
@@ -22,7 +22,7 @@ function Modal({ title, isOpen, onClose, children }: ModalProps) {
         role="dialog"
         aria-modal="true"
         aria-labelledby="modal-title"
-        className="flex h-auto w-125 flex-col items-center gap-10 rounded-[28px] bg-black-0 p-8"
+        className="relative z-10 flex h-auto w-125 flex-col items-center gap-10 rounded-[28px] bg-black-0 p-8"
       >
         <div className="flex items-center justify-between w-full h-13">
           <h2 id="modal-title" className="h2-semibold">

--- a/src/shared/components/widget/dashboard-header/DashboardHeader.stories.tsx
+++ b/src/shared/components/widget/dashboard-header/DashboardHeader.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import DashboardHeader from './DashboardHeader';
+
+const meta: Meta<typeof DashboardHeader> = {
+  title: 'Widget/DashboardHeader',
+  component: DashboardHeader,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    entryCode: {
+      control: 'text',
+      description: '수업 입장 코드',
+    },
+    dashboardUrl: {
+      control: 'text',
+      description: '대시보드 링크 URL',
+    },
+    participantCount: {
+      control: 'number',
+      description: '참여 인원 수',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DashboardHeader>;
+
+export const Default: Story = {
+  args: {
+    entryCode: 'KDDEHG',
+    dashboardUrl: 'https://example.com/dashboard',
+    participantCount: 14,
+  },
+};
+
+export const HighParticipantCount: Story = {
+  args: {
+    entryCode: 'ABCDEF',
+    dashboardUrl: 'https://example.com/dashboard/large',
+    participantCount: 128,
+  },
+};
+
+export const ShortCode: Story = {
+  args: {
+    entryCode: 'XY1234',
+    dashboardUrl: 'https://example.com/dashboard/short',
+    participantCount: 3,
+  },
+};

--- a/src/shared/components/widget/dashboard-header/DashboardHeader.tsx
+++ b/src/shared/components/widget/dashboard-header/DashboardHeader.tsx
@@ -1,9 +1,9 @@
+import { useState } from 'react';
 import { cn } from '@/lib/utils';
 
 interface DashboardHeaderProps {
   logoOnly?: boolean;
   entryCode?: string;
-  dashboardUrl?: string;
   participantCount?: number;
 }
 
@@ -106,12 +106,24 @@ const pillButtonClass = cn(
 function DashboardHeader({
   logoOnly,
   entryCode,
-  dashboardUrl,
   participantCount,
 }: DashboardHeaderProps) {
-  function handleDashboardLinkClick() {
-    if (!dashboardUrl) return;
-    window.open(dashboardUrl, '_blank', 'noopener,noreferrer');
+  const [isCodeCopied, setIsCodeCopied] = useState(false);
+  const [isLinkCopied, setIsLinkCopied] = useState(false);
+
+  async function handleCopyCodeClick() {
+    if (!entryCode) return;
+    await navigator.clipboard.writeText(entryCode);
+    setIsCodeCopied(true);
+    setTimeout(() => setIsCodeCopied(false), 2000);
+  }
+
+  async function handleCopyStudentLinkClick() {
+    if (!entryCode) return;
+    const studentLinkUrl = `${window.location.origin}/?lessonCode=${entryCode}`;
+    await navigator.clipboard.writeText(studentLinkUrl);
+    setIsLinkCopied(true);
+    setTimeout(() => setIsLinkCopied(false), 2000);
   }
 
   return (
@@ -121,16 +133,20 @@ function DashboardHeader({
       </span>
       {!logoOnly && (
         <div className="flex flex-row items-center gap-2.5">
-          <button type="button" className={pillButtonClass}>
-            <span>{entryCode}</span>
+          <button
+            type="button"
+            className={pillButtonClass}
+            onClick={handleCopyCodeClick}
+          >
+            <span>{isCodeCopied ? '복사됨' : entryCode}</span>
             <CopyIcon />
           </button>
           <button
             type="button"
             className={pillButtonClass}
-            onClick={handleDashboardLinkClick}
+            onClick={handleCopyStudentLinkClick}
           >
-            <span>link</span>
+            <span>{isLinkCopied ? '복사됨' : 'link'}</span>
             <LinkIcon />
           </button>
           <button type="button" className={pillButtonClass}>

--- a/src/shared/components/widget/dashboard-header/DashboardHeader.tsx
+++ b/src/shared/components/widget/dashboard-header/DashboardHeader.tsx
@@ -1,9 +1,10 @@
 import { cn } from '@/lib/utils';
 
 interface DashboardHeaderProps {
-  entryCode: string;
-  dashboardUrl: string;
-  participantCount: number;
+  logoOnly?: boolean;
+  entryCode?: string;
+  dashboardUrl?: string;
+  participantCount?: number;
 }
 
 function CopyIcon() {
@@ -103,37 +104,41 @@ const pillButtonClass = cn(
 );
 
 function DashboardHeader({
+  logoOnly,
   entryCode,
   dashboardUrl,
   participantCount,
 }: DashboardHeaderProps) {
   function handleDashboardLinkClick() {
+    if (!dashboardUrl) return;
     window.open(dashboardUrl, '_blank', 'noopener,noreferrer');
   }
 
   return (
-    <header className="flex flex-row items-center justify-between w-full bg-blue-300 px-[120px] py-6">
-      <span className="text-black-0 font-semibold text-[30px] leading-[36px]">
+    <header className="flex flex-row items-center justify-between w-full bg-blue-300 px-30 py-6">
+      <span className="text-black-0 font-semibold text-[30px] leading-9">
         Composite
       </span>
-      <div className="flex flex-row items-center gap-[10px]">
-        <button type="button" className={pillButtonClass}>
-          <span>{entryCode}</span>
-          <CopyIcon />
-        </button>
-        <button
-          type="button"
-          className={pillButtonClass}
-          onClick={handleDashboardLinkClick}
-        >
-          <span>link</span>
-          <LinkIcon />
-        </button>
-        <button type="button" className={pillButtonClass}>
-          <span>{participantCount}</span>
-          <PersonIcon />
-        </button>
-      </div>
+      {!logoOnly && (
+        <div className="flex flex-row items-center gap-2.5">
+          <button type="button" className={pillButtonClass}>
+            <span>{entryCode}</span>
+            <CopyIcon />
+          </button>
+          <button
+            type="button"
+            className={pillButtonClass}
+            onClick={handleDashboardLinkClick}
+          >
+            <span>link</span>
+            <LinkIcon />
+          </button>
+          <button type="button" className={pillButtonClass}>
+            <span>{participantCount}</span>
+            <PersonIcon />
+          </button>
+        </div>
+      )}
     </header>
   );
 }

--- a/src/shared/components/widget/dashboard-header/DashboardHeader.tsx
+++ b/src/shared/components/widget/dashboard-header/DashboardHeader.tsx
@@ -1,0 +1,141 @@
+import { cn } from '@/lib/utils';
+
+interface DashboardHeaderProps {
+  entryCode: string;
+  dashboardUrl: string;
+  participantCount: number;
+}
+
+function CopyIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        x="4.5"
+        y="4.5"
+        width="7"
+        height="7"
+        rx="1.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="none"
+      />
+      <rect
+        x="1.5"
+        y="1.5"
+        width="7"
+        height="7"
+        rx="1.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="white"
+      />
+    </svg>
+  );
+}
+
+function LinkIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9.5 3H13V6.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M13 3L7 9"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M6.5 4H3.5C2.95 4 2.5 4.45 2.5 5V12.5C2.5 13.05 2.95 13.5 3.5 13.5H11C11.55 13.5 12 13.05 12 12.5V9.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function PersonIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="8" cy="5" r="2.5" stroke="currentColor" strokeWidth="1.5" />
+      <path
+        d="M2.5 13.5C2.5 11.015 5.015 9 8 9C10.985 9 13.5 11.015 13.5 13.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+const pillButtonClass = cn(
+  'flex flex-row items-center justify-center gap-[10px]',
+  'px-4 py-2',
+  'bg-black-0 rounded-[14px]',
+  'label-medium text-black-500',
+  'cursor-pointer',
+  'hover:bg-black-100',
+  'transition-colors',
+);
+
+function DashboardHeader({
+  entryCode,
+  dashboardUrl,
+  participantCount,
+}: DashboardHeaderProps) {
+  function handleDashboardLinkClick() {
+    window.open(dashboardUrl, '_blank', 'noopener,noreferrer');
+  }
+
+  return (
+    <header className="flex flex-row items-center justify-between w-full bg-blue-300 px-[120px] py-6">
+      <span className="text-black-0 font-semibold text-[30px] leading-[36px]">
+        Composite
+      </span>
+      <div className="flex flex-row items-center gap-[10px]">
+        <button type="button" className={pillButtonClass}>
+          <span>{entryCode}</span>
+          <CopyIcon />
+        </button>
+        <button
+          type="button"
+          className={pillButtonClass}
+          onClick={handleDashboardLinkClick}
+        >
+          <span>link</span>
+          <LinkIcon />
+        </button>
+        <button type="button" className={pillButtonClass}>
+          <span>{participantCount}</span>
+          <PersonIcon />
+        </button>
+      </div>
+    </header>
+  );
+}
+
+export default DashboardHeader;


### PR DESCRIPTION
## 📋 PR 요약

수업 입장/개설 흐름을 담당하는 메인 페이지와, 교사가 위젯을 추가·관리하는 대시보드 페이지를 연결했습니다.

---

## 🎯 작업 배경 및 이유

실시간 수업 도구의 두 핵심 화면인 랜딩 페이지와 대시보드가 연결되어있지 않아 전체 흐름을 확인할 수 없었습니다. 공통 컴포넌트 계층부터 페이지까지 순차적으로 쌓아올려 화면 단위 동작을 검증할 수 있는 기반을 마련하기 위해 이 작업을 진행했습니다.

---

## 💻 주요 변경 사항

**사이트 헤더 / 대시보드 헤더 (`shared/components/widget/dashboard-header`)**
- 메인·대시보드 페이지 공통으로 사용하는 사이트 헤더 위젯 구현
- 입장 코드, 대시보드 링크, 참가자 수를 props로 수신하는 구조

**메인 페이지 (`page/main`, `features/main`)**
- 히어로 섹션, 영상 미리보기 섹션, 입장/개설 폼(EntranceSection), 위젯 소개 카드(WidgetDescriptionCard) 수정
- 수업 입장(JoinLessonModal), 수업 찾기(FindLessonModal), 수업 만들기(CreateLessonModal) 모달 수정
- 수업 만들기 제출 후 대시보드 페이지로 라우팅 연결

**대시보드 페이지 (`page/dashboard`, `features/dashboard`)**
- `@dnd-kit`을 사용한 위젯 드래그 앤 드롭 정렬 기능 구현 (masonry 레이아웃)
- 위젯 추가 모달(AddWidgetModal)에서 각 위젯 생성 모달로 연결
- 퀴즈·투표는 생성 모달을 통해, 질문·메모·강의자료는 즉시 대시보드에 렌더링
- 위젯이 없을 때 빈 상태 안내 문구 표시

**라우팅 및 프로젝트 설정**
- `App.tsx`에 메인(`/`) 및 대시보드(`/dashboard/:lessonName/:teacherName`) 라우팅 구조 추가

---

## 🖼️ 스크린샷 / 화면 녹화


## 💬 리뷰어에게