### PR TITLE
feat: 위젯 옵션 버튼 구현

### DIFF
--- a/src/features/lecture-materials/ui/LectureMaterialsStudent.tsx
+++ b/src/features/lecture-materials/ui/LectureMaterialsStudent.tsx
@@ -1,5 +1,4 @@
-import IconButton from '@/shared/components/ui/icon-button/IconButton';
-import WidgetIcon from '@/shared/components/ui/widget-icon/WidgetIcon';
+import { StudentWidgetContainer } from '@/shared/components/widget/widget-container/WidgetContainer';
 import EmptyFileIllustration from './components/EmptyFileIllustration';
 import MaterialBlock from './blocks/MaterialBlock';
 import type { LectureMaterial } from '../types';
@@ -14,19 +13,12 @@ function LectureMaterialsStudent({
   onDownload,
 }: LectureMaterialsStudentProps) {
   return (
-    <article className="relative w-130">
-      <div className="flex flex-row items-center justify-between px-4 py-3 bg-white border border-black-200 rounded-t-[20px]">
-        <div className="flex flex-row items-center gap-3">
-          <WidgetIcon iconName="file" size={36} />
-          <div className="flex flex-col gap-1">
-            <span className="body-medium text-black-500">강의 자료</span>
-            <span className="label-regular text-black-200">강의 자료 위젯</span>
-          </div>
-        </div>
-        <IconButton iconName="more" className="hover:bg-black-50" />
-      </div>
-
-      <div className="flex flex-col items-center gap-5 px-4 pt-4 pb-5 bg-black-0 border-x border-b border-black-200 rounded-b-[20px]">
+    <StudentWidgetContainer
+      iconName="file"
+      title="강의 자료"
+      description="강의 자료 위젯"
+    >
+      <div className="flex flex-col items-center gap-5 px-4 pt-4 pb-5">
         {materials.length === 0 ? (
           <div className="flex flex-col items-center gap-2.5 py-2.5">
             <EmptyFileIllustration />
@@ -44,7 +36,7 @@ function LectureMaterialsStudent({
           </ul>
         )}
       </div>
-    </article>
+    </StudentWidgetContainer>
   );
 }
 

--- a/src/features/lecture-materials/ui/LectureMaterialsTeacher.tsx
+++ b/src/features/lecture-materials/ui/LectureMaterialsTeacher.tsx
@@ -1,5 +1,4 @@
-import IconButton from '@/shared/components/ui/icon-button/IconButton';
-import WidgetIcon from '@/shared/components/ui/widget-icon/WidgetIcon';
+import { TeacherWidgetContainer } from '@/shared/components/widget/widget-container/WidgetContainer';
 import MaterialBlock from './blocks/MaterialBlock';
 import UploadBlock from './blocks/UploadBlock';
 import type { LectureMaterial } from '../types';
@@ -18,19 +17,12 @@ function LectureMaterialsTeacher({
   onDelete,
 }: LectureMaterialsTeacherProps) {
   return (
-    <article className="relative w-130">
-      <div className="flex flex-row items-center justify-between px-4 py-3 bg-white border border-black-200 rounded-t-[20px]">
-        <div className="flex flex-row items-center gap-3">
-          <WidgetIcon iconName="file" size={36} />
-          <div className="flex flex-col gap-1">
-            <span className="body-medium text-black-500">강의 자료</span>
-            <span className="label-regular text-black-200">강의 자료 위젯</span>
-          </div>
-        </div>
-        <IconButton iconName="more" className="hover:bg-black-50" />
-      </div>
-
-      <div className="flex flex-col gap-5 px-4 pt-4 pb-5 bg-black-0 border-x border-b border-black-200 rounded-b-[20px]">
+    <TeacherWidgetContainer
+      iconName="file"
+      title="강의 자료"
+      description="강의 자료 위젯"
+    >
+      <div className="flex flex-col gap-5 px-4 pt-4 pb-5">
         <UploadBlock hasFiles={materials.length > 0} onUpload={onUpload} />
 
         {materials.length > 0 && (
@@ -48,7 +40,7 @@ function LectureMaterialsTeacher({
           </ul>
         )}
       </div>
-    </article>
+    </TeacherWidgetContainer>
   );
 }
 

--- a/src/features/memo/ui/MemoStudent.tsx
+++ b/src/features/memo/ui/MemoStudent.tsx
@@ -1,5 +1,4 @@
-import WidgetIcon from '@/shared/components/ui/widget-icon/WidgetIcon';
-import IconButton from '@/shared/components/ui/icon-button/IconButton';
+import { StudentWidgetContainer } from '@/shared/components/widget/widget-container/WidgetContainer';
 import MemoItem from '@/features/memo/ui/blocks/MemoItem';
 
 interface MemoStudentProps {
@@ -16,23 +15,16 @@ function MemoStudent({
   memo,
 }: MemoStudentProps) {
   return (
-    <div className="flex flex-col w-130">
-      <div className="flex flex-row justify-between items-center px-4 py-3 h-[60px] bg-white border border-black-200 rounded-t-[20px]">
-        <div className="flex flex-row items-center gap-3">
-          <WidgetIcon iconName="note" size={36} />
-          <div className="flex flex-col gap-1">
-            <span className="body-medium text-black-500">{widgetName}</span>
-            <span className="label-regular text-black-200">
-              {widgetDescription}
-            </span>
-          </div>
-        </div>
-        <IconButton iconName="more" shape="square" />
-      </div>
-      <div className="flex flex-col items-start px-4 pt-4 pb-5 gap-2 bg-black-0 border-x border-b border-black-200 rounded-b-[20px] w-[520px]">
+    <StudentWidgetContainer
+      iconName="note"
+      title={widgetName}
+      description={widgetDescription}
+      width="w-[520px]"
+    >
+      <div className="flex flex-col items-start px-4 pt-4 pb-5 gap-2">
         <MemoItem title={title} memo={memo} isEditable={false} />
       </div>
-    </div>
+    </StudentWidgetContainer>
   );
 }
 

--- a/src/features/memo/ui/MemoTeacher.tsx
+++ b/src/features/memo/ui/MemoTeacher.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
-import WidgetIcon from '@/shared/components/ui/widget-icon/WidgetIcon';
-import IconButton from '@/shared/components/ui/icon-button/IconButton';
+import { TeacherWidgetContainer } from '@/shared/components/widget/widget-container/WidgetContainer';
 import MemoItem from '@/features/memo/ui/blocks/MemoItem';
 
 interface MemoTeacherProps {
@@ -20,20 +19,13 @@ function MemoTeacher({
   const [memo, setMemo] = useState(initialMemo);
 
   return (
-    <div className="flex flex-col w-[520px]">
-      <div className="flex flex-row justify-between items-center px-4 py-3 h-[60px] bg-white border border-black-200 rounded-t-[20px]">
-        <div className="flex flex-row items-center gap-3">
-          <WidgetIcon iconName="note" size={36} />
-          <div className="flex flex-col gap-1">
-            <span className="body-medium text-black-500">{widgetName}</span>
-            <span className="label-regular text-black-200">
-              {widgetDescription}
-            </span>
-          </div>
-        </div>
-        <IconButton iconName="more" shape="square" />
-      </div>
-      <div className="flex flex-col items-start px-4 pt-4 pb-5 gap-2 bg-black-0 border-x border-b border-black-200 rounded-b-[20px] w-[520px]">
+    <TeacherWidgetContainer
+      iconName="note"
+      title={widgetName}
+      description={widgetDescription}
+      width="w-[520px]"
+    >
+      <div className="flex flex-col items-start px-4 pt-4 pb-5 gap-2">
         <MemoItem
           title={title}
           memo={memo}
@@ -42,7 +34,7 @@ function MemoTeacher({
           onMemoChange={setMemo}
         />
       </div>
-    </div>
+    </TeacherWidgetContainer>
   );
 }
 

--- a/src/features/question/ui/QuestionStudent.tsx
+++ b/src/features/question/ui/QuestionStudent.tsx
@@ -1,5 +1,4 @@
-import WidgetIcon from '@/shared/components/ui/widget-icon/WidgetIcon';
-import IconButton from '@/shared/components/ui/icon-button/IconButton';
+import { StudentWidgetContainer } from '@/shared/components/widget/widget-container/WidgetContainer';
 import QuestionInputCard from './blocks/QuestionInputCard';
 import QuestionCard from './blocks/QuestionCard';
 import Pagination from './blocks/Pagination';
@@ -31,26 +30,13 @@ function QuestionStudent({
   );
 
   return (
-    <section
-      className="flex flex-col w-130"
-      aria-labelledby="question-widget-title"
+    <StudentWidgetContainer
+      iconName="question"
+      title={widgetName}
+      description={widgetDescription}
+      width="w-[520px]"
     >
-      <div className="flex flex-row justify-between items-center px-4 py-3 h-[60px] bg-white border border-black-200 rounded-t-[20px]">
-        <div className="flex flex-row items-center gap-3">
-          <WidgetIcon iconName="question" size={36} />
-          <div className="flex flex-col gap-1">
-            <p
-              id="question-widget-title"
-              className="body-medium text-black-500"
-            >
-              {widgetName}
-            </p>
-            <p className="label-regular text-black-200">{widgetDescription}</p>
-          </div>
-        </div>
-        <IconButton iconName="more" shape="square" aria-label="메뉴 열기" />
-      </div>
-      <div className="flex flex-col items-start px-4 pt-4 pb-5 gap-2 bg-black-0 border-x border-b border-black-200 rounded-b-[20px] w-[520px]">
+      <div className="flex flex-col items-start px-4 pt-4 pb-5 gap-2">
         <QuestionInputCard onSubmit={onSubmitQuestion} />
         <div className="w-full flex flex-col gap-2" aria-label="질문 목록">
           {questions.length === 0 ? (
@@ -78,7 +64,7 @@ function QuestionStudent({
           )}
         </div>
       </div>
-    </section>
+    </StudentWidgetContainer>
   );
 }
 

--- a/src/features/question/ui/QuestionTeacher.tsx
+++ b/src/features/question/ui/QuestionTeacher.tsx
@@ -1,6 +1,4 @@
-import WidgetIcon from '@/shared/components/ui/widget-icon/WidgetIcon';
-import IconButton from '@/shared/components/ui/icon-button/IconButton';
-
+import { TeacherWidgetContainer } from '@/shared/components/widget/widget-container/WidgetContainer';
 import QuestionCard from './blocks/QuestionCard';
 import Pagination from './blocks/Pagination';
 
@@ -39,26 +37,13 @@ function QuestionTeacher({
     questions?.slice(startIndex, startIndex + itemsPerPage) ?? [];
 
   return (
-    <section
-      className="flex flex-col w-130"
-      aria-labelledby="teacher-question-title"
+    <TeacherWidgetContainer
+      iconName="question"
+      title={widgetName}
+      description={widgetDescription}
+      width="w-[520px]"
     >
-      <div className="flex flex-row justify-between items-center px-4 py-3 h-[60px] bg-white border border-black-200 rounded-t-[20px]">
-        <div className="flex flex-row items-center gap-3">
-          <WidgetIcon iconName="question" size={36} />
-          <div className="flex flex-col gap-1">
-            <p
-              id="teacher-question-title"
-              className="body-medium text-black-500"
-            >
-              {widgetName}
-            </p>
-            <p className="label-regular text-black-200">{widgetDescription}</p>
-          </div>
-        </div>
-        <IconButton iconName="more" shape="square" aria-label="메뉴 열기" />
-      </div>
-      <div className="flex flex-col items-start px-4 pt-4 pb-5 gap-2 bg-black-0 border-x border-b border-black-200 rounded-b-[20px] w-[520px]">
+      <div className="flex flex-col items-start px-4 pt-4 pb-5 gap-2">
         {questions.length === 0 ? (
           <p className="w-full text-center py-4 body-regular text-black-200">
             등록된 질문이 없습니다
@@ -82,7 +67,7 @@ function QuestionTeacher({
           </div>
         )}
       </div>
-    </section>
+    </TeacherWidgetContainer>
   );
 }
 

--- a/src/features/quiz/ui/QuizStudent.tsx
+++ b/src/features/quiz/ui/QuizStudent.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
 import Modal from '@/shared/components/ui/modal/Modal';
-import WidgetIcon from '@/shared/components/ui/widget-icon/WidgetIcon';
+import { StudentWidgetContainer } from '@/shared/components/widget/widget-container/WidgetContainer';
 import Button from '@/shared/components/ui/button/Button';
-import Icon from '@/shared/components/ui/icon/Icon';
 import QuizSelection from './blocks/QuizSelection';
 import QuizFooter from './blocks/QuizFooter';
 import QuizResult from './blocks/QuizResult';
@@ -52,82 +51,72 @@ function QuizStudent({
 
   return (
     <div className="relative w-130">
-      <div className="flex flex-row items-center justify-between px-4 py-3 bg-black-0 border border-black-200 rounded-t-[20px]">
-        <div className="flex flex-row items-center gap-3">
-          <WidgetIcon iconName="quiz" size={36} />
-          <div className="flex flex-col gap-1">
-            <span className="body-medium text-black-500">퀴즈</span>
-            <span className="label-regular text-black-200">퀴즈 위젯</span>
-          </div>
-        </div>
-        <button
-          type="button"
-          className="flex items-center justify-center w-8 h-8 rounded-lg cursor-pointer hover:bg-black-50 transition-colors"
-        >
-          <Icon name="more" size={16} />
-        </button>
-      </div>
+      <StudentWidgetContainer
+        iconName="quiz"
+        title="퀴즈"
+        description="퀴즈 위젯"
+      >
+        <div className="flex flex-col gap-5 px-4 pt-4 pb-5">
+          <p className="body-regular text-black-500">{question}</p>
 
-      <div className="flex flex-col gap-5 px-4 pt-4 pb-5 bg-black-0 border-x border-b border-black-200 rounded-b-[20px]">
-        <p className="body-regular text-black-500">{question}</p>
-
-        <div className="flex flex-col gap-5">
-          {choices.map((choice, index) => (
-            <button
-              key={choice}
-              type="button"
-              disabled={isEnded}
-              onClick={() => setSelectedIndex(index)}
-              className="cursor-pointer disabled:cursor-not-allowed bg-transparent w-full"
-            >
-              <QuizSelection
-                index={index + 1}
-                content={choice}
-                state={getSelectionState(index)}
-              />
-            </button>
-          ))}
-        </div>
-
-        <QuizFooter
-          statusSlot={
-            <div className="flex flex-row items-center gap-2 px-4 py-2 bg-black-50 rounded-[14px] label-regular text-black-500">
-              <svg
-                width="16"
-                height="12"
-                viewBox="0 0 16 12"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
+          <div className="flex flex-col gap-5">
+            {choices.map((choice, index) => (
+              <button
+                key={choice}
+                type="button"
+                disabled={isEnded}
+                onClick={() => setSelectedIndex(index)}
+                className="cursor-pointer disabled:cursor-not-allowed bg-transparent w-full"
               >
-                <path
-                  d="M2.33301 3.47317C2.33314 2.87434 2.49682 2.28572 2.80817 1.76441C3.11951 1.24311 3.56794 0.80683 4.10995 0.497916C4.65195 0.189001 5.26912 0.0179413 5.90157 0.00133611C6.53401 -0.0152691 7.16026 0.123144 7.71952 0.403144C8.27879 0.683144 8.75209 1.09522 9.09348 1.59939C9.43488 2.10355 9.63279 2.68269 9.66799 3.28059C9.7032 3.87848 9.57451 4.47485 9.29442 5.0118C9.01433 5.54874 8.59234 6.00805 8.06941 6.34513C9.19554 6.73606 10.1723 7.43702 10.874 8.35778C11.5757 9.27855 11.9701 10.377 12.0067 11.5118C12.0051 11.6341 11.9537 11.7512 11.8631 11.8384C11.7725 11.9257 11.6498 11.9765 11.5206 11.9802C11.3914 11.9839 11.2656 11.9401 11.1697 11.8581C11.0737 11.7761 11.015 11.6622 11.0057 11.5402C10.9659 10.3094 10.4215 9.14172 9.48761 8.28446C8.55376 7.42719 7.30395 6.94776 6.00301 6.94776C4.70208 6.94776 3.45226 7.42719 2.51842 8.28446C1.58457 9.14172 1.04009 10.3094 1.00035 11.5402C0.993666 11.6639 0.936068 11.7802 0.839893 11.8642C0.743718 11.9481 0.616616 11.9931 0.485815 11.9895C0.355015 11.9859 0.23092 11.9339 0.140115 11.8447C0.0493107 11.7555 -0.000980916 11.6362 1.44997e-05 11.5124C0.0364184 10.3775 0.430849 9.27894 1.13254 8.35805C1.83422 7.43715 2.81105 6.7361 3.93728 6.34513C3.44284 6.02641 3.0382 5.59813 2.75859 5.09758C2.47899 4.59703 2.33289 4.03937 2.33301 3.47317ZM6.00335 0.946702C5.29539 0.946702 4.61644 1.21288 4.11584 1.68669C3.61525 2.16049 3.33401 2.80311 3.33401 3.47317C3.33401 4.14323 3.61525 4.78585 4.11584 5.25965C4.61644 5.73346 5.29539 5.99964 6.00335 5.99964C6.7113 5.99964 7.39025 5.73346 7.89085 5.25965C8.39145 4.78585 8.67268 4.14323 8.67268 3.47317C8.67268 2.80311 8.39145 2.16049 7.89085 1.68669C7.39025 1.21288 6.7113 0.946702 6.00335 0.946702ZM11.5355 3.47317C11.4372 3.47317 11.3407 3.47949 11.2459 3.49212C11.1798 3.50333 11.1119 3.50182 11.0464 3.48766C10.9808 3.47351 10.919 3.44701 10.8645 3.40975C10.81 3.37248 10.7641 3.32521 10.7293 3.27076C10.6945 3.21631 10.6717 3.15579 10.6622 3.09281C10.6527 3.02984 10.6567 2.9657 10.674 2.90421C10.6912 2.84273 10.7214 2.78516 10.7627 2.73495C10.8039 2.68474 10.8555 2.64291 10.9142 2.61196C10.9729 2.58101 11.0376 2.56157 11.1044 2.5548C11.7682 2.46397 12.4449 2.58461 13.0283 2.89772C13.6116 3.21083 14.0684 3.69864 14.3267 4.28437C14.5851 4.87011 14.6303 5.52052 14.4553 6.13325C14.2803 6.74598 13.895 7.28624 13.36 7.669C14.1464 8.00227 14.8141 8.54379 15.2825 9.22823C15.751 9.91267 16.0001 10.7108 16 11.5263C16 11.6519 15.9473 11.7724 15.8534 11.8613C15.7595 11.9501 15.6322 12 15.4995 12C15.3668 12 15.2395 11.9501 15.1456 11.8613C15.0517 11.7724 14.999 11.6519 14.999 11.5263C14.9992 10.8214 14.7594 10.1353 14.3151 9.56956C13.8708 9.00387 13.2457 8.58879 12.5325 8.38589L12.1762 8.28483V7.22624L12.4498 7.09423C12.8554 6.89978 13.1799 6.58164 13.3709 6.19117C13.562 5.8007 13.6084 5.36068 13.5027 4.94216C13.3971 4.52363 13.1454 4.15103 12.7885 3.8845C12.4316 3.61796 11.9902 3.47306 11.5355 3.47317Z"
-                  fill="black"
+                <QuizSelection
+                  index={index + 1}
+                  content={choice}
+                  state={getSelectionState(index)}
                 />
-              </svg>
-              <span>{participantCount}명 참여</span>
-            </div>
-          }
-          actionSlot={
-            <button
-              type="button"
-              disabled={isEnded}
-              onClick={() => setIsSubmitModalOpen(true)}
-              className="flex items-center justify-center px-5 py-2.5 rounded-[14px] label-medium text-black-0 transition-colors cursor-pointer disabled:bg-black-200 disabled:cursor-not-allowed bg-blue-300 hover:bg-blue-200"
-            >
-              제출
-            </button>
-          }
-        />
+              </button>
+            ))}
+          </div>
 
-        {isEnded && (
-          <QuizResult
-            correctRate={correctRate}
-            correctAnswerIndex={correctAnswerIndex}
-            isStudent
-            isCorrect={isCorrect}
+          <QuizFooter
+            statusSlot={
+              <div className="flex flex-row items-center gap-2 px-4 py-2 bg-black-50 rounded-[14px] label-regular text-black-500">
+                <svg
+                  width="16"
+                  height="12"
+                  viewBox="0 0 16 12"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M2.33301 3.47317C2.33314 2.87434 2.49682 2.28572 2.80817 1.76441C3.11951 1.24311 3.56794 0.80683 4.10995 0.497916C4.65195 0.189001 5.26912 0.0179413 5.90157 0.00133611C6.53401 -0.0152691 7.16026 0.123144 7.71952 0.403144C8.27879 0.683144 8.75209 1.09522 9.09348 1.59939C9.43488 2.10355 9.63279 2.68269 9.66799 3.28059C9.7032 3.87848 9.57451 4.47485 9.29442 5.0118C9.01433 5.54874 8.59234 6.00805 8.06941 6.34513C9.19554 6.73606 10.1723 7.43702 10.874 8.35778C11.5757 9.27855 11.9701 10.377 12.0067 11.5118C12.0051 11.6341 11.9537 11.7512 11.8631 11.8384C11.7725 11.9257 11.6498 11.9765 11.5206 11.9802C11.3914 11.9839 11.2656 11.9401 11.1697 11.8581C11.0737 11.7761 11.015 11.6622 11.0057 11.5402C10.9659 10.3094 10.4215 9.14172 9.48761 8.28446C8.55376 7.42719 7.30395 6.94776 6.00301 6.94776C4.70208 6.94776 3.45226 7.42719 2.51842 8.28446C1.58457 9.14172 1.04009 10.3094 1.00035 11.5402C0.993666 11.6639 0.936068 11.7802 0.839893 11.8642C0.743718 11.9481 0.616616 11.9931 0.485815 11.9895C0.355015 11.9859 0.23092 11.9339 0.140115 11.8447C0.0493107 11.7555 -0.000980916 11.6362 1.44997e-05 11.5124C0.0364184 10.3775 0.430849 9.27894 1.13254 8.35805C1.83422 7.43715 2.81105 6.7361 3.93728 6.34513C3.44284 6.02641 3.0382 5.59813 2.75859 5.09758C2.47899 4.59703 2.33289 4.03937 2.33301 3.47317ZM6.00335 0.946702C5.29539 0.946702 4.61644 1.21288 4.11584 1.68669C3.61525 2.16049 3.33401 2.80311 3.33401 3.47317C3.33401 4.14323 3.61525 4.78585 4.11584 5.25965C4.61644 5.73346 5.29539 5.99964 6.00335 5.99964C6.7113 5.99964 7.39025 5.73346 7.89085 5.25965C8.39145 4.78585 8.67268 4.14323 8.67268 3.47317C8.67268 2.80311 8.39145 2.16049 7.89085 1.68669C7.39025 1.21288 6.7113 0.946702 6.00335 0.946702ZM11.5355 3.47317C11.4372 3.47317 11.3407 3.47949 11.2459 3.49212C11.1798 3.50333 11.1119 3.50182 11.0464 3.48766C10.9808 3.47351 10.919 3.44701 10.8645 3.40975C10.81 3.37248 10.7641 3.32521 10.7293 3.27076C10.6945 3.21631 10.6717 3.15579 10.6622 3.09281C10.6527 3.02984 10.6567 2.9657 10.674 2.90421C10.6912 2.84273 10.7214 2.78516 10.7627 2.73495C10.8039 2.68474 10.8555 2.64291 10.9142 2.61196C10.9729 2.58101 11.0376 2.56157 11.1044 2.5548C11.7682 2.46397 12.4449 2.58461 13.0283 2.89772C13.6116 3.21083 14.0684 3.69864 14.3267 4.28437C14.5851 4.87011 14.6303 5.52052 14.4553 6.13325C14.2803 6.74598 13.895 7.28624 13.36 7.669C14.1464 8.00227 14.8141 8.54379 15.2825 9.22823C15.751 9.91267 16.0001 10.7108 16 11.5263C16 11.6519 15.9473 11.7724 15.8534 11.8613C15.7595 11.9501 15.6322 12 15.4995 12C15.3668 12 15.2395 11.9501 15.1456 11.8613C15.0517 11.7724 14.999 11.6519 14.999 11.5263C14.9992 10.8214 14.7594 10.1353 14.3151 9.56956C13.8708 9.00387 13.2457 8.58879 12.5325 8.38589L12.1762 8.28483V7.22624L12.4498 7.09423C12.8554 6.89978 13.1799 6.58164 13.3709 6.19117C13.562 5.8007 13.6084 5.36068 13.5027 4.94216C13.3971 4.52363 13.1454 4.15103 12.7885 3.8845C12.4316 3.61796 11.9902 3.47306 11.5355 3.47317Z"
+                    fill="black"
+                  />
+                </svg>
+                <span>{participantCount}명 참여</span>
+              </div>
+            }
+            actionSlot={
+              <button
+                type="button"
+                disabled={isEnded}
+                onClick={() => setIsSubmitModalOpen(true)}
+                className="flex items-center justify-center px-5 py-2.5 rounded-[14px] label-medium text-black-0 transition-colors cursor-pointer disabled:bg-black-200 disabled:cursor-not-allowed bg-blue-300 hover:bg-blue-200"
+              >
+                제출
+              </button>
+            }
           />
-        )}
-      </div>
+
+          {isEnded && (
+            <QuizResult
+              correctRate={correctRate}
+              correctAnswerIndex={correctAnswerIndex}
+              isStudent
+              isCorrect={isCorrect}
+            />
+          )}
+        </div>
+      </StudentWidgetContainer>
 
       <Modal
         title="퀴즈 제출"

--- a/src/features/quiz/ui/QuizTeacher.tsx
+++ b/src/features/quiz/ui/QuizTeacher.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
 import Modal from '@/shared/components/ui/modal/Modal';
-import WidgetIcon from '@/shared/components/ui/widget-icon/WidgetIcon';
+import { TeacherWidgetContainer } from '@/shared/components/widget/widget-container/WidgetContainer';
 import Button from '@/shared/components/ui/button/Button';
-import Icon from '@/shared/components/ui/icon/Icon';
 import QuizSelection from './blocks/QuizSelection';
 import QuizFooter from './blocks/QuizFooter';
 import QuizResult from './blocks/QuizResult';
@@ -54,97 +53,87 @@ function QuizTeacher({
 
   return (
     <div className="relative w-130">
-      <div className="flex flex-row items-center justify-between px-4 py-3 bg-black-0 border border-black-200 rounded-t-[20px]">
-        <div className="flex flex-row items-center gap-3">
-          <WidgetIcon iconName="quiz" size={36} />
-          <div className="flex flex-col gap-1">
-            <span className="body-medium text-black-500">퀴즈</span>
-            <span className="label-regular text-black-200">퀴즈 위젯</span>
+      <TeacherWidgetContainer
+        iconName="quiz"
+        title="퀴즈"
+        description="퀴즈 위젯"
+      >
+        <div className="flex flex-col gap-5 px-4 pt-4 pb-5">
+          <p className="body-regular text-black-500">{question}</p>
+
+          <div className="flex flex-col gap-2.5">
+            {choices.map((choice, index) => (
+              <QuizSelection
+                key={choice}
+                index={index + 1}
+                content={choice}
+                state={getSelectionState(index)}
+              />
+            ))}
           </div>
-        </div>
-        <button
-          type="button"
-          className="flex items-center justify-center w-8 h-8 rounded-lg cursor-pointer hover:bg-black-50 transition-colors"
-        >
-          <Icon name="more" size={16} />
-        </button>
-      </div>
 
-      <div className="flex flex-col gap-5 px-4 pt-4 pb-5 bg-black-0 border-x border-b border-black-200 rounded-b-[20px]">
-        <p className="body-regular text-black-500">{question}</p>
-
-        <div className="flex flex-col gap-2.5">
-          {choices.map((choice, index) => (
-            <QuizSelection
-              key={choice}
-              index={index + 1}
-              content={choice}
-              state={getSelectionState(index)}
-            />
-          ))}
-        </div>
-
-        <QuizFooter
-          statusSlot={
-            <div className="relative">
+          <QuizFooter
+            statusSlot={
+              <div className="relative">
+                <button
+                  type="button"
+                  onClick={() => setIsStatusPopupOpen(!isStatusPopupOpen)}
+                  className="flex flex-row items-center gap-2 px-4 py-2 bg-black-50 rounded-[14px] label-regular text-black-500 cursor-pointer hover:bg-black-100 transition-colors"
+                >
+                  <svg
+                    width="16"
+                    height="12"
+                    viewBox="0 0 16 12"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M2.33301 3.47317C2.33314 2.87434 2.49682 2.28572 2.80817 1.76441C3.11951 1.24311 3.56794 0.80683 4.10995 0.497916C4.65195 0.189001 5.26912 0.0179413 5.90157 0.00133611C6.53401 -0.0152691 7.16026 0.123144 7.71952 0.403144C8.27879 0.683144 8.75209 1.09522 9.09348 1.59939C9.43488 2.10355 9.63279 2.68269 9.66799 3.28059C9.7032 3.87848 9.57451 4.47485 9.29442 5.0118C9.01433 5.54874 8.59234 6.00805 8.06941 6.34513C9.19554 6.73606 10.1723 7.43702 10.874 8.35778C11.5757 9.27855 11.9701 10.377 12.0067 11.5118C12.0051 11.6341 11.9537 11.7512 11.8631 11.8384C11.7725 11.9257 11.6498 11.9765 11.5206 11.9802C11.3914 11.9839 11.2656 11.9401 11.1697 11.8581C11.0737 11.7761 11.015 11.6622 11.0057 11.5402C10.9659 10.3094 10.4215 9.14172 9.48761 8.28446C8.55376 7.42719 7.30395 6.94776 6.00301 6.94776C4.70208 6.94776 3.45226 7.42719 2.51842 8.28446C1.58457 9.14172 1.04009 10.3094 1.00035 11.5402C0.993666 11.6639 0.936068 11.7802 0.839893 11.8642C0.743718 11.9481 0.616616 11.9931 0.485815 11.9895C0.355015 11.9859 0.23092 11.9339 0.140115 11.8447C0.0493107 11.7555 -0.000980916 11.6362 1.44997e-05 11.5124C0.0364184 10.3775 0.430849 9.27894 1.13254 8.35805C1.83422 7.43715 2.81105 6.7361 3.93728 6.34513C3.44284 6.02641 3.0382 5.59813 2.75859 5.09758C2.47899 4.59703 2.33289 4.03937 2.33301 3.47317ZM6.00335 0.946702C5.29539 0.946702 4.61644 1.21288 4.11584 1.68669C3.61525 2.16049 3.33401 2.80311 3.33401 3.47317C3.33401 4.14323 3.61525 4.78585 4.11584 5.25965C4.61644 5.73346 5.29539 5.99964 6.00335 5.99964C6.7113 5.99964 7.39025 5.73346 7.89085 5.25965C8.39145 4.78585 8.67268 4.14323 8.67268 3.47317C8.67268 2.80311 8.39145 2.16049 7.89085 1.68669C7.39025 1.21288 6.7113 0.946702 6.00335 0.946702ZM11.5355 3.47317C11.4372 3.47317 11.3407 3.47949 11.2459 3.49212C11.1798 3.50333 11.1119 3.50182 11.0464 3.48766C10.9808 3.47351 10.919 3.44701 10.8645 3.40975C10.81 3.37248 10.7641 3.32521 10.7293 3.27076C10.6945 3.21631 10.6717 3.15579 10.6622 3.09281C10.6527 3.02984 10.6567 2.9657 10.674 2.90421C10.6912 2.84273 10.7214 2.78516 10.7627 2.73495C10.8039 2.68474 10.8555 2.64291 10.9142 2.61196C10.9729 2.58101 11.0376 2.56157 11.1044 2.5548C11.7682 2.46397 12.4449 2.58461 13.0283 2.89772C13.6116 3.21083 14.0684 3.69864 14.3267 4.28437C14.5851 4.87011 14.6303 5.52052 14.4553 6.13325C14.2803 6.74598 13.895 7.28624 13.36 7.669C14.1464 8.00227 14.8141 8.54379 15.2825 9.22823C15.751 9.91267 16.0001 10.7108 16 11.5263C16 11.6519 15.9473 11.7724 15.8534 11.8613C15.7595 11.9501 15.6322 12 15.4995 12C15.3668 12 15.2395 11.9501 15.1456 11.8613C15.0517 11.7724 14.999 11.6519 14.999 11.5263C14.9992 10.8214 14.7594 10.1353 14.3151 9.56956C13.8708 9.00387 13.2457 8.58879 12.5325 8.38589L12.1762 8.28483V7.22624L12.4498 7.09423C12.8554 6.89978 13.1799 6.58164 13.3709 6.19117C13.562 5.8007 13.6084 5.36068 13.5027 4.94216C13.3971 4.52363 13.1454 4.15103 12.7885 3.8845C12.4316 3.61796 11.9902 3.47306 11.5355 3.47317Z"
+                      fill="black"
+                    />
+                  </svg>
+                  <span>현황</span>
+                </button>
+                {isStatusPopupOpen && (
+                  <div className="absolute bottom-full left-0 mb-2 bg-black-0 border border-black-100 rounded-2xl px-5 py-3 shadow-md min-w-45 z-10">
+                    <div className="flex flex-col gap-2">
+                      {participantStatuses.map((status) => (
+                        <p
+                          key={status.choiceIndex}
+                          className="description-regular text-black-500"
+                        >
+                          {status.choiceIndex + 1}:{' '}
+                          {status.participants.join(', ')}
+                        </p>
+                      ))}
+                    </div>
+                    <p className="description-regular text-black-200 mt-2">
+                      {participantCount}명 참여
+                    </p>
+                  </div>
+                )}
+              </div>
+            }
+            actionSlot={
               <button
                 type="button"
-                onClick={() => setIsStatusPopupOpen(!isStatusPopupOpen)}
-                className="flex flex-row items-center gap-2 px-4 py-2 bg-black-50 rounded-[14px] label-regular text-black-500 cursor-pointer hover:bg-black-100 transition-colors"
+                disabled={isEnded}
+                onClick={() => setIsEndModalOpen(true)}
+                className="flex items-center justify-center px-5 py-2.5 rounded-[14px] label-medium text-black-0 transition-colors cursor-pointer disabled:bg-black-200 disabled:cursor-not-allowed bg-blue-300 hover:bg-blue-200"
               >
-                <svg
-                  width="16"
-                  height="12"
-                  viewBox="0 0 16 12"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M2.33301 3.47317C2.33314 2.87434 2.49682 2.28572 2.80817 1.76441C3.11951 1.24311 3.56794 0.80683 4.10995 0.497916C4.65195 0.189001 5.26912 0.0179413 5.90157 0.00133611C6.53401 -0.0152691 7.16026 0.123144 7.71952 0.403144C8.27879 0.683144 8.75209 1.09522 9.09348 1.59939C9.43488 2.10355 9.63279 2.68269 9.66799 3.28059C9.7032 3.87848 9.57451 4.47485 9.29442 5.0118C9.01433 5.54874 8.59234 6.00805 8.06941 6.34513C9.19554 6.73606 10.1723 7.43702 10.874 8.35778C11.5757 9.27855 11.9701 10.377 12.0067 11.5118C12.0051 11.6341 11.9537 11.7512 11.8631 11.8384C11.7725 11.9257 11.6498 11.9765 11.5206 11.9802C11.3914 11.9839 11.2656 11.9401 11.1697 11.8581C11.0737 11.7761 11.015 11.6622 11.0057 11.5402C10.9659 10.3094 10.4215 9.14172 9.48761 8.28446C8.55376 7.42719 7.30395 6.94776 6.00301 6.94776C4.70208 6.94776 3.45226 7.42719 2.51842 8.28446C1.58457 9.14172 1.04009 10.3094 1.00035 11.5402C0.993666 11.6639 0.936068 11.7802 0.839893 11.8642C0.743718 11.9481 0.616616 11.9931 0.485815 11.9895C0.355015 11.9859 0.23092 11.9339 0.140115 11.8447C0.0493107 11.7555 -0.000980916 11.6362 1.44997e-05 11.5124C0.0364184 10.3775 0.430849 9.27894 1.13254 8.35805C1.83422 7.43715 2.81105 6.7361 3.93728 6.34513C3.44284 6.02641 3.0382 5.59813 2.75859 5.09758C2.47899 4.59703 2.33289 4.03937 2.33301 3.47317ZM6.00335 0.946702C5.29539 0.946702 4.61644 1.21288 4.11584 1.68669C3.61525 2.16049 3.33401 2.80311 3.33401 3.47317C3.33401 4.14323 3.61525 4.78585 4.11584 5.25965C4.61644 5.73346 5.29539 5.99964 6.00335 5.99964C6.7113 5.99964 7.39025 5.73346 7.89085 5.25965C8.39145 4.78585 8.67268 4.14323 8.67268 3.47317C8.67268 2.80311 8.39145 2.16049 7.89085 1.68669C7.39025 1.21288 6.7113 0.946702 6.00335 0.946702ZM11.5355 3.47317C11.4372 3.47317 11.3407 3.47949 11.2459 3.49212C11.1798 3.50333 11.1119 3.50182 11.0464 3.48766C10.9808 3.47351 10.919 3.44701 10.8645 3.40975C10.81 3.37248 10.7641 3.32521 10.7293 3.27076C10.6945 3.21631 10.6717 3.15579 10.6622 3.09281C10.6527 3.02984 10.6567 2.9657 10.674 2.90421C10.6912 2.84273 10.7214 2.78516 10.7627 2.73495C10.8039 2.68474 10.8555 2.64291 10.9142 2.61196C10.9729 2.58101 11.0376 2.56157 11.1044 2.5548C11.7682 2.46397 12.4449 2.58461 13.0283 2.89772C13.6116 3.21083 14.0684 3.69864 14.3267 4.28437C14.5851 4.87011 14.6303 5.52052 14.4553 6.13325C14.2803 6.74598 13.895 7.28624 13.36 7.669C14.1464 8.00227 14.8141 8.54379 15.2825 9.22823C15.751 9.91267 16.0001 10.7108 16 11.5263C16 11.6519 15.9473 11.7724 15.8534 11.8613C15.7595 11.9501 15.6322 12 15.4995 12C15.3668 12 15.2395 11.9501 15.1456 11.8613C15.0517 11.7724 14.999 11.6519 14.999 11.5263C14.9992 10.8214 14.7594 10.1353 14.3151 9.56956C13.8708 9.00387 13.2457 8.58879 12.5325 8.38589L12.1762 8.28483V7.22624L12.4498 7.09423C12.8554 6.89978 13.1799 6.58164 13.3709 6.19117C13.562 5.8007 13.6084 5.36068 13.5027 4.94216C13.3971 4.52363 13.1454 4.15103 12.7885 3.8845C12.4316 3.61796 11.9902 3.47306 11.5355 3.47317Z"
-                    fill="black"
-                  />
-                </svg>
-                <span>현황</span>
+                종료
               </button>
-              {isStatusPopupOpen && (
-                <div className="absolute bottom-full left-0 mb-2 bg-black-0 border border-black-100 rounded-2xl px-5 py-3 shadow-md min-w-45 z-10">
-                  <div className="flex flex-col gap-2">
-                    {participantStatuses.map((status) => (
-                      <p
-                        key={status.choiceIndex}
-                        className="description-regular text-black-500"
-                      >
-                        {status.choiceIndex + 1}:{' '}
-                        {status.participants.join(', ')}
-                      </p>
-                    ))}
-                  </div>
-                  <p className="description-regular text-black-200 mt-2">
-                    {participantCount}명 참여
-                  </p>
-                </div>
-              )}
-            </div>
-          }
-          actionSlot={
-            <button
-              type="button"
-              disabled={isEnded}
-              onClick={() => setIsEndModalOpen(true)}
-              className="flex items-center justify-center px-5 py-2.5 rounded-[14px] label-medium text-black-0 transition-colors cursor-pointer disabled:bg-black-200 disabled:cursor-not-allowed bg-blue-300 hover:bg-blue-200"
-            >
-              종료
-            </button>
-          }
-        />
-
-        {isEnded && (
-          <QuizResult
-            correctRate={correctRate}
-            correctAnswerIndex={correctIndex + 1}
+            }
           />
-        )}
-      </div>
+
+          {isEnded && (
+            <QuizResult
+              correctRate={correctRate}
+              correctAnswerIndex={correctIndex + 1}
+            />
+          )}
+        </div>
+      </TeacherWidgetContainer>
 
       <Modal
         title="퀴즈 종료"

--- a/src/features/vote/ui/VoteStudent.tsx
+++ b/src/features/vote/ui/VoteStudent.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import WidgetIcon from '@/shared/components/ui/widget-icon/WidgetIcon';
+import { StudentWidgetContainer } from '@/shared/components/widget/widget-container/WidgetContainer';
 import OptionBadge from './blocks/OptionBadge';
 import SelectionList, { type VoteSelectionItem } from './blocks/SelectionList';
 import Footer from './blocks/Footer';
@@ -42,17 +42,8 @@ function VoteStudent({
   };
 
   return (
-    <div className="flex flex-col w-130">
-      <div className="box-border flex flex-row items-center px-4 py-3 h-15 bg-white border border-black-200 rounded-[20px_20px_0_0]">
-        <div className="flex flex-row items-center gap-3">
-          <WidgetIcon iconName="vote" size={36} />
-          <div className="flex flex-col gap-1">
-            <span className="body-medium text-black-500">{title}</span>
-            <span className="label-regular text-black-200">투표</span>
-          </div>
-        </div>
-      </div>
-      <div className="box-border flex flex-col gap-5 px-4 pt-4 pb-5 bg-black-0 border-[0_1px_1px_1px] border-black-200 rounded-[0_0_20px_20px]">
+    <StudentWidgetContainer iconName="vote" title={title} description="투표">
+      <div className="box-border flex flex-col gap-5 px-4 pt-4 pb-5">
         <div className="flex flex-row items-center gap-2.5 w-full">
           <p className="flex-1 body-regular text-black-500">{description}</p>
           <OptionBadge options={options} />
@@ -70,7 +61,7 @@ function VoteStudent({
           isSubmitDisabled={selectedIds.length === 0}
         />
       </div>
-    </div>
+    </StudentWidgetContainer>
   );
 }
 

--- a/src/features/vote/ui/VoteTeacher.tsx
+++ b/src/features/vote/ui/VoteTeacher.tsx
@@ -1,4 +1,4 @@
-import WidgetIcon from '@/shared/components/ui/widget-icon/WidgetIcon';
+import { TeacherWidgetContainer } from '@/shared/components/widget/widget-container/WidgetContainer';
 import OptionBadge from './blocks/OptionBadge';
 import SelectionList, { type VoteSelectionItem } from './blocks/SelectionList';
 import Footer from './blocks/Footer';
@@ -21,17 +21,8 @@ function VoteTeacher({
   onStopClick,
 }: VoteTeacherProps) {
   return (
-    <div className="flex flex-col w-130">
-      <div className="box-border flex flex-row items-center px-4 py-3 h-15 bg-white border border-black-200 rounded-[20px_20px_0_0]">
-        <div className="flex flex-row items-center gap-3">
-          <WidgetIcon iconName="vote" size={36} />
-          <div className="flex flex-col gap-1">
-            <span className="body-medium text-black-500">{title}</span>
-            <span className="label-regular text-black-200">투표</span>
-          </div>
-        </div>
-      </div>
-      <div className="box-border flex flex-col gap-5 px-4 pt-4 pb-5 bg-black-0 border-[0_1px_1px_1px] border-black-200 rounded-[0_0_20px_20px]">
+    <TeacherWidgetContainer iconName="vote" title={title} description="투표">
+      <div className="flex flex-col gap-5 px-4 pt-4 pb-5">
         <div className="flex flex-row items-center gap-2.5 w-full">
           <p className="flex-1 body-regular text-black-500">{description}</p>
           <OptionBadge options={options} />
@@ -43,7 +34,7 @@ function VoteTeacher({
           submitLabel="종료하기"
         />
       </div>
-    </div>
+    </TeacherWidgetContainer>
   );
 }
 

--- a/src/shared/components/ui/more-action-menu/MoreActionMenu.stories.tsx
+++ b/src/shared/components/ui/more-action-menu/MoreActionMenu.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import MoreActionMenu from './MoreActionMenu';
+
+const meta: Meta<typeof MoreActionMenu> = {
+  title: 'UI/MoreActionMenu',
+  component: MoreActionMenu,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="relative h-32 w-40">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/shared/components/ui/more-action-menu/MoreActionMenu.tsx
+++ b/src/shared/components/ui/more-action-menu/MoreActionMenu.tsx
@@ -1,4 +1,6 @@
 import { cn } from '@/lib/utils';
+import ActionButton from '@/shared/components/ui/action-button/ActionButton';
+import Icon, { type IconName } from '@/shared/components/ui/icon/Icon';
 
 interface MoreActionMenuProps {
   className?: string;
@@ -7,49 +9,22 @@ interface MoreActionMenuProps {
 }
 
 interface ActionItemProps {
-  iconName: 'edit' | 'delete';
+  variant: 'edit' | 'delete';
+  iconName: IconName;
   label: string;
-  colorClassName: string;
-  iconColor: string;
   onClick?: () => void;
 }
 
-function ActionIcon({
-  iconName,
-  iconColor,
-}: Pick<ActionItemProps, 'iconName' | 'iconColor'>) {
+function ActionItem({ variant, iconName, label, onClick }: ActionItemProps) {
   return (
-    <span
-      aria-hidden
-      className="size-4 shrink-0"
-      style={{
-        backgroundColor: iconColor,
-        mask: `url(/assets/icons/${iconName}.svg) center / contain no-repeat`,
-        WebkitMask: `url(/assets/icons/${iconName}.svg) center / contain no-repeat`,
-      }}
-    />
-  );
-}
-
-function ActionItem({
-  iconName,
-  label,
-  colorClassName,
-  iconColor,
-  onClick,
-}: ActionItemProps) {
-  return (
-    <button
-      type="button"
-      className={cn(
-        'flex h-9 w-full items-center gap-2 rounded-lg px-3 text-left label-medium transition-colors hover:bg-black-50',
-        colorClassName,
-      )}
+    <ActionButton
+      variant={variant}
+      className="h-9 w-full justify-start gap-2 px-3 label-medium hover:bg-black-50"
       onClick={onClick}
     >
-      <ActionIcon iconName={iconName} iconColor={iconColor} />
+      <Icon name={iconName} size={16} decorative className="size-4 shrink-0" />
       <span>{label}</span>
-    </button>
+    </ActionButton>
   );
 }
 
@@ -67,17 +42,15 @@ function MoreActionMenu({
       role="menu"
     >
       <ActionItem
+        variant="edit"
         iconName="edit"
         label="수정"
-        colorClassName="text-black-500"
-        iconColor="#1E1E1E"
         onClick={onEditClick}
       />
       <ActionItem
+        variant="delete"
         iconName="delete"
         label="삭제"
-        colorClassName="text-[#FF0000]"
-        iconColor="#FF0000"
         onClick={onDeleteClick}
       />
     </div>

--- a/src/shared/components/ui/more-action-menu/MoreActionMenu.tsx
+++ b/src/shared/components/ui/more-action-menu/MoreActionMenu.tsx
@@ -1,0 +1,87 @@
+import { cn } from '@/lib/utils';
+
+interface MoreActionMenuProps {
+  className?: string;
+  onEditClick?: () => void;
+  onDeleteClick?: () => void;
+}
+
+interface ActionItemProps {
+  iconName: 'edit' | 'delete';
+  label: string;
+  colorClassName: string;
+  iconColor: string;
+  onClick?: () => void;
+}
+
+function ActionIcon({
+  iconName,
+  iconColor,
+}: Pick<ActionItemProps, 'iconName' | 'iconColor'>) {
+  return (
+    <span
+      aria-hidden
+      className="size-4 shrink-0"
+      style={{
+        backgroundColor: iconColor,
+        mask: `url(/assets/icons/${iconName}.svg) center / contain no-repeat`,
+        WebkitMask: `url(/assets/icons/${iconName}.svg) center / contain no-repeat`,
+      }}
+    />
+  );
+}
+
+function ActionItem({
+  iconName,
+  label,
+  colorClassName,
+  iconColor,
+  onClick,
+}: ActionItemProps) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        'flex h-9 w-full items-center gap-2 rounded-lg px-3 text-left label-medium transition-colors hover:bg-black-50',
+        colorClassName,
+      )}
+      onClick={onClick}
+    >
+      <ActionIcon iconName={iconName} iconColor={iconColor} />
+      <span>{label}</span>
+    </button>
+  );
+}
+
+function MoreActionMenu({
+  className,
+  onEditClick,
+  onDeleteClick,
+}: MoreActionMenuProps) {
+  return (
+    <div
+      className={cn(
+        'absolute right-0 top-full z-20 mt-2 flex w-24 flex-col gap-1 rounded-xl border border-black-100 bg-white p-1 shadow-md',
+        className,
+      )}
+      role="menu"
+    >
+      <ActionItem
+        iconName="edit"
+        label="수정"
+        colorClassName="text-black-500"
+        iconColor="#1E1E1E"
+        onClick={onEditClick}
+      />
+      <ActionItem
+        iconName="delete"
+        label="삭제"
+        colorClassName="text-[#FF0000]"
+        iconColor="#FF0000"
+        onClick={onDeleteClick}
+      />
+    </div>
+  );
+}
+
+export default MoreActionMenu;

--- a/src/shared/components/widget/widget-container/WidgetContainer.stories.tsx
+++ b/src/shared/components/widget/widget-container/WidgetContainer.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  StudentWidgetContainer,
+  TeacherWidgetContainer,
+} from './WidgetContainer';
+
+const meta: Meta<typeof TeacherWidgetContainer> = {
+  title: 'Widget/WidgetContainer',
+  component: TeacherWidgetContainer,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sampleContent = (
+  <div className="flex flex-col gap-3 px-4 pt-4 pb-5">
+    <p className="body-regular text-black-500">
+      위젯 본문 영역에 들어가는 콘텐츠입니다.
+    </p>
+    <div className="h-12 rounded-xl bg-black-50" />
+    <div className="h-12 rounded-xl bg-black-50" />
+  </div>
+);
+
+export const Teacher: Story = {
+  render: () => (
+    <TeacherWidgetContainer
+      iconName="quiz"
+      title="퀴즈"
+      description="퀴즈 위젯"
+    >
+      {sampleContent}
+    </TeacherWidgetContainer>
+  ),
+};
+
+export const Student: Story = {
+  render: () => (
+    <StudentWidgetContainer
+      iconName="quiz"
+      title="퀴즈"
+      description="퀴즈 위젯"
+    >
+      {sampleContent}
+    </StudentWidgetContainer>
+  ),
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <TeacherWidgetContainer
+        iconName="note"
+        title="수업자 메모"
+        description="옵션 버튼 표시"
+      >
+        {sampleContent}
+      </TeacherWidgetContainer>
+      <StudentWidgetContainer
+        iconName="note"
+        title="학생 메모"
+        description="옵션 버튼 없음"
+      >
+        {sampleContent}
+      </StudentWidgetContainer>
+    </div>
+  ),
+};

--- a/src/shared/components/widget/widget-container/WidgetContainer.tsx
+++ b/src/shared/components/widget/widget-container/WidgetContainer.tsx
@@ -1,6 +1,7 @@
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import WidgetIcon from '@/shared/components/ui/widget-icon/WidgetIcon';
 import IconButton from '@/shared/components/ui/icon-button/IconButton';
+import MoreActionMenu from '@/shared/components/ui/more-action-menu/MoreActionMenu';
 import type { WidgetName } from '@/shared/types/widget.type';
 
 interface WidgetContainerBaseProps {
@@ -10,7 +11,8 @@ interface WidgetContainerBaseProps {
   width?: string;
   children: ReactNode;
   showMore?: boolean;
-  onMoreClick?: () => void;
+  onEditClick?: () => void;
+  onDeleteClick?: () => void;
 }
 
 interface StudentWidgetContainerProps {
@@ -27,7 +29,8 @@ interface TeacherWidgetContainerProps {
   description: string;
   width?: string;
   children: ReactNode;
-  onMoreClick?: () => void;
+  onEditClick?: () => void;
+  onDeleteClick?: () => void;
 }
 
 function WidgetContainerBase({
@@ -37,8 +40,25 @@ function WidgetContainerBase({
   width = 'w-130',
   children,
   showMore = false,
-  onMoreClick,
+  onEditClick,
+  onDeleteClick,
 }: WidgetContainerBaseProps) {
+  const [isActionMenuOpen, setIsActionMenuOpen] = useState(false);
+
+  function handleMoreClick() {
+    setIsActionMenuOpen((previous) => !previous);
+  }
+
+  function handleEditClick() {
+    onEditClick?.();
+    setIsActionMenuOpen(false);
+  }
+
+  function handleDeleteClick() {
+    onDeleteClick?.();
+    setIsActionMenuOpen(false);
+  }
+
   return (
     <div className={`flex flex-col ${width}`}>
       <div className="flex flex-row items-center justify-between px-4 py-3 bg-white border border-black-200 rounded-t-[20px]">
@@ -50,7 +70,20 @@ function WidgetContainerBase({
           </div>
         </div>
         {showMore && (
-          <IconButton iconName="more" shape="square" onClick={onMoreClick} />
+          <div className="relative">
+            <IconButton
+              iconName="more"
+              shape="square"
+              onClick={handleMoreClick}
+              aria-label="위젯 옵션 열기"
+            />
+            {isActionMenuOpen && (
+              <MoreActionMenu
+                onEditClick={handleEditClick}
+                onDeleteClick={handleDeleteClick}
+              />
+            )}
+          </div>
         )}
       </div>
 

--- a/src/shared/components/widget/widget-container/WidgetContainer.tsx
+++ b/src/shared/components/widget/widget-container/WidgetContainer.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from 'react';
+import WidgetIcon from '@/shared/components/ui/widget-icon/WidgetIcon';
+import IconButton from '@/shared/components/ui/icon-button/IconButton';
+import type { WidgetName } from '@/shared/types/widget.type';
+
+interface WidgetContainerBaseProps {
+  iconName: WidgetName;
+  title: string;
+  description: string;
+  width?: string;
+  children: ReactNode;
+  showMore?: boolean;
+  onMoreClick?: () => void;
+}
+
+interface StudentWidgetContainerProps {
+  iconName: WidgetName;
+  title: string;
+  description: string;
+  width?: string;
+  children: ReactNode;
+}
+
+interface TeacherWidgetContainerProps {
+  iconName: WidgetName;
+  title: string;
+  description: string;
+  width?: string;
+  children: ReactNode;
+  onMoreClick?: () => void;
+}
+
+function WidgetContainerBase({
+  iconName,
+  title,
+  description,
+  width = 'w-130',
+  children,
+  showMore = false,
+  onMoreClick,
+}: WidgetContainerBaseProps) {
+  return (
+    <div className={`flex flex-col ${width}`}>
+      <div className="flex flex-row items-center justify-between px-4 py-3 bg-white border border-black-200 rounded-t-[20px]">
+        <div className="flex flex-row items-center gap-3">
+          <WidgetIcon iconName={iconName} size={36} />
+          <div className="flex flex-col gap-1">
+            <span className="body-medium text-black-500">{title}</span>
+            <span className="label-regular text-black-200">{description}</span>
+          </div>
+        </div>
+        {showMore && (
+          <IconButton iconName="more" shape="square" onClick={onMoreClick} />
+        )}
+      </div>
+
+      <div className="flex flex-col bg-black-0 border-x border-b border-black-200 rounded-b-[20px]">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function StudentWidgetContainer(props: StudentWidgetContainerProps) {
+  return <WidgetContainerBase {...props} />;
+}
+
+function WidgetContainer(props: TeacherWidgetContainerProps) {
+  return <WidgetContainerBase {...props} showMore />;
+}
+
+export { WidgetContainer as TeacherWidgetContainer };
+export default WidgetContainer;

--- a/src/shared/components/widget/widget-container/WidgetContainer.tsx
+++ b/src/shared/components/widget/widget-container/WidgetContainer.tsx
@@ -98,9 +98,6 @@ export function StudentWidgetContainer(props: StudentWidgetContainerProps) {
   return <WidgetContainerBase {...props} />;
 }
 
-function WidgetContainer(props: TeacherWidgetContainerProps) {
+export function TeacherWidgetContainer(props: TeacherWidgetContainerProps) {
   return <WidgetContainerBase {...props} showMore />;
 }
-
-export { WidgetContainer as TeacherWidgetContainer };
-export default WidgetContainer;


### PR DESCRIPTION
## 📋 PR 요약
WidgetContainer 컴포넌트에 위젯의 공통 스타일을 묶어서 유지보수 기능을 높였습니다.
MoreActionMenu 컴포넌트에 위젯을 수정/삭제할 수 있는 버튼을 구현하였습니다.

## 🎯 작업 배경 및 이유
유지보수를 위해 5개의 위젯에 공통적으로 적용되는 기본 위젯 스타일을 공통 컴포넌트로 묶을 필요가 있었습니다. 
따라서 WidgetContainer 컴포넌트에 위젯 스타일을 공통으로 적용하여 유지보수 기능을 높였습니다.
수업자는 생성된 위젯을 수정하거나 삭제할 수 있지만 UI가 구현되어있지 않았습니다. 따라서 moreActionMenu 컴포넌트를 통해 more 버튼 클릭 시 수정/삭제 버튼이 표시될 수 있게 구현하였습니다.

## 🔗 관련 링크
- 기획서(Notion): 
- 테크 스펙(Google Docs): 
- Figma: 
- Slack: 

## 💻 주요 변경 사항
WidgetContainer : StudentWidgetContainer/TeacherWidgetContainer로 구분하여 수업자 위젯에는 수정/삭제할 수 있는 버튼이 있고 학생 위젯은 읽기 전용으로 구현하였습니다.
MoreActioniMenu : 수업자가 생성한 위젯을 편집할 수 있는 옵션을 표시하고 수정/삭제할 수 있는 버튼의 UI를 구현하였습니다.

## 🖼️ 스크린샷 / 화면 녹화
<img width="228" height="152" alt="image" src="https://github.com/user-attachments/assets/8865b844-a62a-45d1-b2c3-948ef0ba38ce" />


## 💬 리뷰어에게
추후 디자인 업데이트를 고려해 간단하게 구현했습니다!