### PR TITLE
fix: 대시보드 라우팅 버그 수정

### DIFF
--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -39,6 +39,7 @@ export default function MainPage() {
   const [submittedJoinCode, setSubmittedJoinCode] = useState('');
   const [submittedFindCode, setSubmittedFindCode] = useState('');
   const [lessonCode, setLessonCode] = useState<string>('');
+  const [teacherName, setTeacherName] = useState<string>('');
 
   const createLessonMutation = useCreateLessonMutation();
 
@@ -53,15 +54,14 @@ export default function MainPage() {
   useEffect(() => {
     if (createLessonMutation.isSuccess && createLessonMutation.data) {
       const lesson = createLessonMutation.data;
-      navigate(
-        `/dashboard/${lessonCode}/${lesson.lessonName}/${lesson.teacherName}`,
-      );
+      navigate(`/dashboard/${lessonCode}/${lesson.lessonName}/${teacherName}`);
     }
   }, [
     createLessonMutation.isSuccess,
     createLessonMutation.data,
     navigate,
     lessonCode,
+    teacherName,
   ]);
 
   const handleCloseModal = () => {
@@ -141,6 +141,7 @@ export default function MainPage() {
         },
         guestToken: guestCredentialsResponse.token,
       });
+      setTeacherName(payload.teacherName);
     } catch {
       // eslint-disable-next-line no-empty
     }


### PR DESCRIPTION
## 📋 PR 요약
수업 생성 후 대시보드로 이동할 때 `teacherName`이 `undefined`로 전달되는 문제를 수정하였습니다.

## 🎯 작업 배경 및 이유
수업 생성 성공 시 `/dashboard/:lessonCode/:lessonName/:teacherName` 경로로 이동합니다.

기존에는 생성 API 응답인 `lesson` 객체에서 `teacherName`을 가져와 URL을 구성했지만, 실제 생성 API 응답에는 `lessonId`와 `lessonName`만 포함되어 있어 `teacherName`이 항상 `undefined`로 전달되는 문제가 있었습니다.

## 🔗 관련 링크
- 기획서(Notion): 
- 테크 스펙(Google Docs): 
- Figma: 
- Slack: 

## 💻 주요 변경 사항
- 수업 생성 요청 시 입력받은 `teacherName`을 상태로 저장하도록 수정
- 생성 성공 후 대시보드 이동 경로에 API 응답값이 아닌 저장된 `teacherName`을 사용하도록 수정