### PR TITLE
refactor: 인증 토큰 요청 인터셉터 적용

### DIFF
--- a/src/features/lesson/api/lesson.api.ts
+++ b/src/features/lesson/api/lesson.api.ts
@@ -38,42 +38,24 @@ export interface AuthenticateLessonResponse {
 
 export async function createLesson(
   body: CreateLessonRequest,
-  guestToken: string,
 ): Promise<CreateLessonResponse> {
-  const response = await http.post<CreateLessonResponse>('/lessons', body, {
-    headers: {
-      Authorization: `Bearer ${guestToken}`,
-    },
-  });
+  const response = await http.post<CreateLessonResponse>('/lessons', body);
   return response.data;
 }
 
 export async function joinLessonAsStudent(
   lessonCode: string,
   body: JoinStudentRequest,
-  token: string,
 ): Promise<JoinStudentResponse> {
   const response = await http.post<JoinStudentResponse>(
     `/lessons/${lessonCode}/students`,
     body,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    },
   );
   return response.data;
 }
 
-export async function fetchLesson(
-  lessonId: number,
-  token: string,
-): Promise<Lesson> {
-  const response = await http.get<Lesson>(`/lessons/${lessonId}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+export async function fetchLesson(lessonId: number): Promise<Lesson> {
+  const response = await http.get<Lesson>(`/lessons/${lessonId}`);
   return response.data;
 }
 
@@ -90,15 +72,9 @@ export interface GetLessonWidgetIdsResponse {
 
 export async function fetchLessonWidgetIds(
   lessonId: number,
-  token: string,
 ): Promise<GetLessonWidgetIdsResponse> {
   const response = await http.get<GetLessonWidgetIdsResponse>(
     `/lessons/${lessonId}/widgets`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    },
   );
   return response.data;
 }

--- a/src/features/lesson/api/lesson.queries.ts
+++ b/src/features/lesson/api/lesson.queries.ts
@@ -8,32 +8,26 @@ import {
   type AuthenticateLessonRequest,
 } from './lesson.api';
 
-export function useLessonQuery(lessonId: number, token: string) {
+export function useLessonQuery(lessonId: number) {
   return useQuery({
-    queryKey: ['lesson', 'detail', lessonId, token],
-    queryFn: () => fetchLesson(lessonId, token),
-    enabled: !!lessonId && !!token,
+    queryKey: ['lesson', 'detail', lessonId],
+    queryFn: () => fetchLesson(lessonId),
+    enabled: !!lessonId,
   });
 }
 
-export function useLessonWidgetIdsQuery(lessonId: number, token: string) {
+export function useLessonWidgetIdsQuery(lessonId: number) {
   return useQuery({
     queryKey: ['lesson', 'widgets', lessonId],
-    queryFn: () => fetchLessonWidgetIds(lessonId, token),
-    enabled: !!lessonId && !!token,
+    queryFn: () => fetchLessonWidgetIds(lessonId),
+    enabled: !!lessonId,
   });
 }
 
 export function useCreateLessonMutation() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({
-      body,
-      guestToken,
-    }: {
-      body: CreateLessonRequest;
-      guestToken: string;
-    }) => createLesson(body, guestToken),
+    mutationFn: (body: CreateLessonRequest) => createLesson(body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['lesson'] });
     },

--- a/src/features/memo/api/memo.api.ts
+++ b/src/features/memo/api/memo.api.ts
@@ -28,52 +28,29 @@ export interface UpdateMemoWidgetRequest {
 
 export async function createMemoWidget(
   body: CreateMemoWidgetRequest,
-  token: string,
 ): Promise<MemoWidget> {
-  const response = await http.post<MemoWidget>('/memoWidgets', body, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+  const response = await http.post<MemoWidget>('/memoWidgets', body);
   return response.data;
 }
 
 export async function fetchMemoWidget(
   memoWidgetId: number,
-  token: string,
 ): Promise<MemoWidget> {
-  const response = await http.get<MemoWidget>(`/memoWidgets/${memoWidgetId}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+  const response = await http.get<MemoWidget>(`/memoWidgets/${memoWidgetId}`);
   return response.data;
 }
 
 export async function updateMemoWidget(
   memoWidgetId: number,
   body: UpdateMemoWidgetRequest,
-  token: string,
 ): Promise<MemoWidget> {
   const response = await http.put<MemoWidget>(
     `/memoWidgets/${memoWidgetId}`,
     body,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    },
   );
   return response.data;
 }
 
-export async function deleteMemoWidget(
-  memoWidgetId: number,
-  token: string,
-): Promise<void> {
-  await http.delete(`/memoWidgets/${memoWidgetId}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+export async function deleteMemoWidget(memoWidgetId: number): Promise<void> {
+  await http.delete(`/memoWidgets/${memoWidgetId}`);
 }

--- a/src/features/memo/api/memo.queries.ts
+++ b/src/features/memo/api/memo.queries.ts
@@ -8,26 +8,25 @@ import {
   type UpdateMemoWidgetRequest,
 } from './memo.api';
 
-export function useCreateMemoWidgetMutation(token: string) {
+export function useCreateMemoWidgetMutation() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (body: CreateMemoWidgetRequest) =>
-      createMemoWidget(body, token),
+    mutationFn: (body: CreateMemoWidgetRequest) => createMemoWidget(body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['memo'] });
     },
   });
 }
 
-export function useMemoWidgetQuery(memoWidgetId: number, token: string) {
+export function useMemoWidgetQuery(memoWidgetId: number) {
   return useQuery({
     queryKey: ['memo', 'detail', memoWidgetId],
-    queryFn: () => fetchMemoWidget(memoWidgetId, token),
-    enabled: !!token,
+    queryFn: () => fetchMemoWidget(memoWidgetId),
+    enabled: !!memoWidgetId,
   });
 }
 
-export function useUpdateMemoWidgetMutation(token: string) {
+export function useUpdateMemoWidgetMutation() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({
@@ -36,7 +35,7 @@ export function useUpdateMemoWidgetMutation(token: string) {
     }: {
       memoWidgetId: number;
       body: UpdateMemoWidgetRequest;
-    }) => updateMemoWidget(memoWidgetId, body, token),
+    }) => updateMemoWidget(memoWidgetId, body),
     onSuccess: (_data, { memoWidgetId }) => {
       queryClient.invalidateQueries({
         queryKey: ['memo', 'detail', memoWidgetId],
@@ -45,10 +44,10 @@ export function useUpdateMemoWidgetMutation(token: string) {
   });
 }
 
-export function useDeleteMemoWidgetMutation(token: string) {
+export function useDeleteMemoWidgetMutation() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (memoWidgetId: number) => deleteMemoWidget(memoWidgetId, token),
+    mutationFn: (memoWidgetId: number) => deleteMemoWidget(memoWidgetId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['memo'] });
     },

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -25,8 +25,6 @@ http.interceptors.request.use((config) => {
 
   if (token) {
     headers.set('Authorization', `Bearer ${token}`);
-  } else {
-    headers.delete('Authorization');
   }
 
   return {

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,13 +1,36 @@
-import axios from 'axios';
+import axios, { AxiosHeaders } from 'axios';
+
+const AUTH_TOKEN_KEY = 'authToken';
 
 export const http = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
 });
 
+export function getAuthToken(): string | null {
+  return localStorage.getItem(AUTH_TOKEN_KEY);
+}
+
 export function setAuthToken(token: string): void {
-  http.defaults.headers.common.Authorization = `Bearer ${token}`;
+  localStorage.setItem(AUTH_TOKEN_KEY, token);
 }
 
 export function clearAuthToken(): void {
+  localStorage.removeItem(AUTH_TOKEN_KEY);
   delete http.defaults.headers.common.Authorization;
 }
+
+http.interceptors.request.use((config) => {
+  const token = getAuthToken();
+  const headers = new AxiosHeaders(config.headers);
+
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  } else {
+    headers.delete('Authorization');
+  }
+
+  return {
+    ...config,
+    headers,
+  };
+});

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -119,23 +119,21 @@ function DashBoardPage() {
   const [widgets, setWidgets] = useState<DashboardWidget[]>([]);
   const hasInitializedRef = useRef(false);
 
-  const authToken = localStorage.getItem('authToken') ?? '';
-  const { data: widgetIdsData } = useLessonWidgetIdsQuery(lessonId, authToken);
+  const { data: widgetIdsData } = useLessonWidgetIdsQuery(lessonId);
   const memoWidgetIds = useMemo(
     () => widgetIdsData?.widgets.memo ?? [],
     [widgetIdsData],
   );
-  const createMemoMutation = useCreateMemoWidgetMutation(authToken);
+  const createMemoMutation = useCreateMemoWidgetMutation();
 
   useEffect(() => {
     if (hasInitializedRef.current) return;
     if (memoWidgetIds.length === 0) return;
-    if (!authToken) return;
 
     const loadMemoWidgets = async () => {
       try {
         const memoWidgetDataArray = await Promise.all(
-          memoWidgetIds.map((id) => fetchMemoWidget(id, authToken)),
+          memoWidgetIds.map((id) => fetchMemoWidget(id)),
         );
         setWidgets(
           memoWidgetDataArray.map((data) => ({
@@ -153,7 +151,7 @@ function DashBoardPage() {
     };
 
     loadMemoWidgets();
-  }, [memoWidgetIds, authToken]);
+  }, [memoWidgetIds]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),

--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -17,6 +17,7 @@ import {
   joinLessonAsStudent,
 } from '@/features/lesson/api/lesson.api';
 import { getGuestToken } from '@/features/guest/api/guest.api';
+import { setAuthToken } from '@/lib/http';
 
 type SelectedId = 'note' | 'file' | 'quiz' | 'vote' | 'question';
 type ModalType = 'join' | 'find' | 'create' | null;
@@ -91,16 +92,11 @@ export default function MainPage() {
       const guestCredentialsResponse = await getGuestToken({
         name: payload.studentName,
       });
-      localStorage.setItem('authToken', guestCredentialsResponse.token);
-      const { lessonId } = await joinLessonAsStudent(
-        payload.lessonCode,
-        { name: payload.studentName },
-        guestCredentialsResponse.token,
-      );
-      const lesson = await fetchLesson(
-        lessonId,
-        guestCredentialsResponse.token,
-      );
+      setAuthToken(guestCredentialsResponse.token);
+      const { lessonId } = await joinLessonAsStudent(payload.lessonCode, {
+        name: payload.studentName,
+      });
+      const lesson = await fetchLesson(lessonId);
       navigate(
         `/dashboard/${payload.lessonCode}/${lessonId}/${lesson.lessonName}/${lesson.teacherName}`,
       );
@@ -119,11 +115,8 @@ export default function MainPage() {
         password: payload.password,
       });
       localStorage.setItem('lessonAuthToken', authResponse.token);
-      localStorage.setItem('authToken', authResponse.token);
-      const lesson = await fetchLesson(
-        authResponse.lessonId,
-        authResponse.token,
-      );
+      setAuthToken(authResponse.token);
+      const lesson = await fetchLesson(authResponse.lessonId);
       navigate(
         `/dashboard/${payload.lessonCode}/${authResponse.lessonId}/${lesson.lessonName}/${lesson.teacherName}`,
       );
@@ -142,15 +135,12 @@ export default function MainPage() {
       const guestCredentialsResponse = await getGuestToken({
         name: payload.teacherName,
       });
-      localStorage.setItem('authToken', guestCredentialsResponse.token);
+      setAuthToken(guestCredentialsResponse.token);
       createLessonMutation.mutate({
-        body: {
-          teacherName: payload.teacherName,
-          lessonName: payload.lessonName,
-          lessonCode: payload.lessonCode,
-          password: payload.password,
-        },
-        guestToken: guestCredentialsResponse.token,
+        teacherName: payload.teacherName,
+        lessonName: payload.lessonName,
+        lessonCode: payload.lessonCode,
+        password: payload.password,
       });
       setTeacherName(payload.teacherName);
     } catch {


### PR DESCRIPTION
## 📋 PR 요약
API 요청마다 개별적으로 주입하던 Authorization 헤더를 공통 HTTP 인터셉터에서 자동으로 처리하도록 변경하였습니다.

## 🎯 작업 배경 및 이유
기존에는 인증이 필요한 API마다 token을 함수 인자로 전달하고, 각 API 함수 내부에서 헤더를 직접 설정했습니다. 
해당 방식은 API가 늘어날수록 중복이 많아지기에 공통 http 클라이언트에서 토큰을 자동 주입하도록 변경하여 인증 처리 책임을 한곳으로 모았습니다.

## 🔗 관련 링크

## 💻 주요 변경 사항
- `http.ts` : authToken 저장/조회/삭제 유틸 정리, Axios request interceptor 추가, 요청 시 localStorage.authToken을 읽어 Authorization 헤더 자동 주입
- API/query 정리
- 페이지 호출부 수정: MainPage, DashBoardPage 수정

## 💬 리뷰어에게
현재 구현된 방식은 http 인스턴스를 사용하는 모든 API 요청에 인증 헤더를 자동으로 주입합니다.
추후에 `skipAuth`같은 옵션을 통해 예외처리하는 구조를 추가하겠습니다!