### PR TITLE
feat: 투표 api 연동 및 학생/수업자 분리 로직 추가

### DIFF
--- a/public/icons/crown.svg
+++ b/public/icons/crown.svg
@@ -1,0 +1,9 @@
+<svg width="20" height="14" viewBox="0 0 20 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path
+    d="M2 12 L1 3 L5 6 L10 2 L15 6 L19 3 L18 12 Z"
+    fill="#FBBF24"
+    stroke="#D97706"
+    stroke-width="0.6"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,7 +8,7 @@ function AppContent() {
     <Routes>
       <Route path="/" element={<MainPage />} />
       <Route
-        path="/dashboard/:lessonCode/:lessonId/:lessonName/:teacherName"
+        path="/dashboard/:role/:lessonCode/:lessonId"
         element={<DashBoardPage />}
       />
     </Routes>

--- a/src/features/dashboard/ui/dashboard-header/DashboardHeader.tsx
+++ b/src/features/dashboard/ui/dashboard-header/DashboardHeader.tsx
@@ -3,7 +3,7 @@ import Button from '@/shared/components/ui/button/Button';
 interface DashBoardHeaderProps {
   lessonName: string;
   teacherName: string;
-  onOpenModal: () => void;
+  onOpenModal?: () => void;
 }
 
 function DashboardHeader({
@@ -17,9 +17,11 @@ function DashboardHeader({
         <h2 className="h2-semibold text-black-500">{lessonName}</h2>
         <p className="body-medium text-black-500">{teacherName}</p>
       </div>
-      <Button variant="blue" size="md" onClick={onOpenModal}>
-        + 위젯 추가
-      </Button>
+      {onOpenModal && (
+        <Button variant="blue" size="md" onClick={onOpenModal}>
+          + 위젯 추가
+        </Button>
+      )}
     </header>
   );
 }

--- a/src/features/memo/ui/MemoStudent.tsx
+++ b/src/features/memo/ui/MemoStudent.tsx
@@ -19,7 +19,6 @@ function MemoStudent({
       iconName="note"
       title={widgetName}
       description={widgetDescription}
-      width="w-[520px]"
     >
       <div className="flex flex-col items-start px-4 pt-4 pb-5 gap-2">
         <MemoItem title={title} memo={memo} isEditable={false} />

--- a/src/features/memo/ui/MemoTeacher.tsx
+++ b/src/features/memo/ui/MemoTeacher.tsx
@@ -19,7 +19,6 @@ function MemoTeacher({
       iconName="note"
       title={widgetName}
       description={widgetDescription}
-      width="w-[520px]"
     >
       <div className="flex flex-col items-start px-4 pt-4 pb-5 gap-2">
         <MemoItem title={title} memo={content} isEditable={false} />

--- a/src/features/question/ui/QuestionStudent.tsx
+++ b/src/features/question/ui/QuestionStudent.tsx
@@ -34,7 +34,6 @@ function QuestionStudent({
       iconName="question"
       title={widgetName}
       description={widgetDescription}
-      width="w-[520px]"
     >
       <div className="flex flex-col items-start px-4 pt-4 pb-5 gap-2">
         <QuestionInputCard onSubmit={onSubmitQuestion} />

--- a/src/features/question/ui/QuestionTeacher.tsx
+++ b/src/features/question/ui/QuestionTeacher.tsx
@@ -41,7 +41,6 @@ function QuestionTeacher({
       iconName="question"
       title={widgetName}
       description={widgetDescription}
-      width="w-[520px]"
     >
       <div className="flex flex-col items-start px-4 pt-4 pb-5 gap-2">
         {questions.length === 0 ? (

--- a/src/features/quiz/ui/QuizStudent.tsx
+++ b/src/features/quiz/ui/QuizStudent.tsx
@@ -50,7 +50,7 @@ function QuizStudent({
   }
 
   return (
-    <div className="relative w-130">
+    <div className="w-full max-w-130">
       <StudentWidgetContainer
         iconName="quiz"
         title="퀴즈"

--- a/src/features/quiz/ui/QuizTeacher.tsx
+++ b/src/features/quiz/ui/QuizTeacher.tsx
@@ -52,7 +52,7 @@ function QuizTeacher({
   }
 
   return (
-    <div className="relative w-130">
+    <div className="w-full max-w-130">
       <TeacherWidgetContainer
         iconName="quiz"
         title="퀴즈"

--- a/src/features/vote/api/vote.api.ts
+++ b/src/features/vote/api/vote.api.ts
@@ -1,67 +1,11 @@
 import { http } from '../../../lib/http';
-
-export type VoteStatus = 'IN_PROGRESS' | 'ENDED';
-
-export interface VoteOptionResponse {
-  id: number;
-  content: string;
-}
-
-export interface AnonymousOptionStatus {
-  optionId: number;
-  count: number;
-}
-
-export interface IdentifiedOptionStatus {
-  optionId: number;
-  voterNames: string[];
-}
-
-export interface VoteParticipationResponse {
-  totalParticipantCount: number;
-  anonymousOptionStatuses?: AnonymousOptionStatus[];
-  identifiedOptionStatuses?: IdentifiedOptionStatus[];
-}
-
-export interface VoteEndedResponse {
-  selectedOptionIds: number[];
-}
-
-export interface VoteWidgetDetail {
-  id: number;
-  title: string;
-  isAnonymous: boolean;
-  isMultiSelectable: boolean;
-  status: VoteStatus;
-  options: VoteOptionResponse[];
-  participationResponse: VoteParticipationResponse;
-  endedResponse?: VoteEndedResponse;
-}
-
-export interface CreateVoteWidgetResponse {
-  id: number;
-  title: string;
-  isAnonymous: boolean;
-  isMultiSelectable: boolean;
-  status: VoteStatus;
-  options: VoteOptionResponse[];
-}
-
-export interface CreateVoteWidgetRequest {
-  lessonId: number;
-  title: string;
-  options: string[];
-  isAnonymous: boolean;
-  isMultiSelectable: boolean;
-}
-
-export interface SubmitVoteRequest {
-  optionIds: number[];
-}
-
-export interface UpdateVoteStatusRequest {
-  status: VoteStatus;
-}
+import type {
+  CreateVoteWidgetRequest,
+  CreateVoteWidgetResponse,
+  SubmitVoteRequest,
+  UpdateVoteStatusRequest,
+  VoteWidgetDetail,
+} from './vote.types';
 
 export async function createVoteWidget(
   body: CreateVoteWidgetRequest,

--- a/src/features/vote/api/vote.api.ts
+++ b/src/features/vote/api/vote.api.ts
@@ -1,0 +1,130 @@
+import { http } from '../../../lib/http';
+
+export type VoteStatus = 'IN_PROGRESS' | 'ENDED';
+
+export interface VoteOptionResponse {
+  id: number;
+  content: string;
+}
+
+export interface AnonymousOptionStatus {
+  optionId: number;
+  count: number;
+}
+
+export interface IdentifiedOptionStatus {
+  optionId: number;
+  voterNames: string[];
+}
+
+export interface VoteParticipationResponse {
+  totalParticipantCount: number;
+  anonymousOptionStatuses?: AnonymousOptionStatus[];
+  identifiedOptionStatuses?: IdentifiedOptionStatus[];
+}
+
+export interface VoteEndedResponse {
+  selectedOptionIds: number[];
+}
+
+export interface VoteWidgetDetail {
+  id: number;
+  title: string;
+  isAnonymous: boolean;
+  isMultiSelectable: boolean;
+  status: VoteStatus;
+  options: VoteOptionResponse[];
+  participationResponse: VoteParticipationResponse;
+  endedResponse?: VoteEndedResponse;
+}
+
+export interface CreateVoteWidgetResponse {
+  id: number;
+  title: string;
+  isAnonymous: boolean;
+  isMultiSelectable: boolean;
+  status: VoteStatus;
+  options: VoteOptionResponse[];
+}
+
+export interface CreateVoteWidgetRequest {
+  lessonId: number;
+  title: string;
+  options: string[];
+  isAnonymous: boolean;
+  isMultiSelectable: boolean;
+}
+
+export interface SubmitVoteRequest {
+  optionIds: number[];
+}
+
+export interface UpdateVoteStatusRequest {
+  status: VoteStatus;
+}
+
+export async function createVoteWidget(
+  body: CreateVoteWidgetRequest,
+  token: string,
+): Promise<CreateVoteWidgetResponse> {
+  const response = await http.post<CreateVoteWidgetResponse>(
+    '/vote-widgets',
+    body,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+  return response.data;
+}
+
+export async function fetchVoteWidget(
+  voteWidgetId: number,
+  token: string,
+): Promise<VoteWidgetDetail> {
+  const response = await http.get<VoteWidgetDetail>(
+    `/vote-widgets/${voteWidgetId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+  return response.data;
+}
+
+export async function deleteVoteWidget(
+  voteWidgetId: number,
+  token: string,
+): Promise<void> {
+  await http.delete(`/vote-widgets/${voteWidgetId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+}
+
+export async function submitVote(
+  voteWidgetId: number,
+  body: SubmitVoteRequest,
+  token: string,
+): Promise<void> {
+  await http.post(`/vote-widgets/${voteWidgetId}/submissions`, body, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+}
+
+export async function updateVoteStatus(
+  voteWidgetId: number,
+  body: UpdateVoteStatusRequest,
+  token: string,
+): Promise<void> {
+  await http.patch(`/vote-widgets/${voteWidgetId}/status`, body, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+}

--- a/src/features/vote/api/vote.mock.ts
+++ b/src/features/vote/api/vote.mock.ts
@@ -1,0 +1,63 @@
+import { http, HttpResponse } from 'msw';
+
+export const voteHandlers = [
+  http.post('/vote-widgets', async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    const options = (body.options as string[]) ?? [];
+    return HttpResponse.json(
+      {
+        id: 1,
+        title: body.title,
+        isAnonymous: body.isAnonymous,
+        isMultiSelectable: body.isMultiSelectable,
+        status: 'IN_PROGRESS',
+        options: options.map((content, index) => ({
+          id: index + 1,
+          content,
+        })),
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.get('/vote-widgets/:voteWidgetId', ({ params }) => {
+    return HttpResponse.json({
+      id: Number(params.voteWidgetId),
+      title: '투표 제목',
+      isAnonymous: false,
+      isMultiSelectable: false,
+      status: 'IN_PROGRESS',
+      options: [
+        { id: 1, content: '선택지 1' },
+        { id: 2, content: '선택지 2' },
+      ],
+      participationResponse: {
+        totalParticipantCount: 0,
+        anonymousOptionStatuses: [
+          { optionId: 1, count: 0 },
+          { optionId: 2, count: 0 },
+        ],
+        identifiedOptionStatuses: [
+          { optionId: 1, voterNames: [] },
+          { optionId: 2, voterNames: [] },
+        ],
+      },
+      endedResponse: {
+        selectedOptionIds: [],
+      },
+    });
+  }),
+
+  http.delete('/vote-widgets/:voteWidgetId', () => {
+    return new HttpResponse(null, { status: 200 });
+  }),
+
+  http.post('/vote-widgets/:voteWidgetId/submissions', () => {
+    return new HttpResponse(null, { status: 200 });
+  }),
+
+  http.patch('/vote-widgets/:voteWidgetId/status', async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json({ status: body.status });
+  }),
+];

--- a/src/features/vote/api/vote.queries.ts
+++ b/src/features/vote/api/vote.queries.ts
@@ -1,0 +1,76 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createVoteWidget,
+  deleteVoteWidget,
+  fetchVoteWidget,
+  submitVote,
+  updateVoteStatus,
+  type CreateVoteWidgetRequest,
+  type SubmitVoteRequest,
+  type UpdateVoteStatusRequest,
+} from './vote.api';
+
+export function useCreateVoteWidgetMutation(token: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateVoteWidgetRequest) =>
+      createVoteWidget(body, token),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['vote'] });
+    },
+  });
+}
+
+export function useVoteWidgetQuery(voteWidgetId: number, token: string) {
+  return useQuery({
+    queryKey: ['vote', 'detail', voteWidgetId],
+    queryFn: () => fetchVoteWidget(voteWidgetId, token),
+    enabled: !!voteWidgetId && !!token,
+  });
+}
+
+export function useSubmitVoteMutation(token: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      voteWidgetId,
+      body,
+    }: {
+      voteWidgetId: number;
+      body: SubmitVoteRequest;
+    }) => submitVote(voteWidgetId, body, token),
+    onSuccess: (_data, { voteWidgetId }) => {
+      queryClient.invalidateQueries({
+        queryKey: ['vote', 'detail', voteWidgetId],
+      });
+    },
+  });
+}
+
+export function useUpdateVoteStatusMutation(token: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      voteWidgetId,
+      body,
+    }: {
+      voteWidgetId: number;
+      body: UpdateVoteStatusRequest;
+    }) => updateVoteStatus(voteWidgetId, body, token),
+    onSuccess: (_data, { voteWidgetId }) => {
+      queryClient.invalidateQueries({
+        queryKey: ['vote', 'detail', voteWidgetId],
+      });
+    },
+  });
+}
+
+export function useDeleteVoteWidgetMutation(token: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (voteWidgetId: number) => deleteVoteWidget(voteWidgetId, token),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['vote'] });
+    },
+  });
+}

--- a/src/features/vote/api/vote.queries.ts
+++ b/src/features/vote/api/vote.queries.ts
@@ -5,10 +5,12 @@ import {
   fetchVoteWidget,
   submitVote,
   updateVoteStatus,
-  type CreateVoteWidgetRequest,
-  type SubmitVoteRequest,
-  type UpdateVoteStatusRequest,
 } from './vote.api';
+import type {
+  CreateVoteWidgetRequest,
+  SubmitVoteRequest,
+  UpdateVoteStatusRequest,
+} from './vote.types';
 
 export function useCreateVoteWidgetMutation(token: string) {
   const queryClient = useQueryClient();

--- a/src/features/vote/api/vote.types.ts
+++ b/src/features/vote/api/vote.types.ts
@@ -1,0 +1,62 @@
+export type VoteStatus = 'IN_PROGRESS' | 'ENDED';
+
+export interface VoteOptionResponse {
+  id: number;
+  content: string;
+}
+
+export interface AnonymousOptionStatus {
+  optionId: number;
+  count: number;
+}
+
+export interface IdentifiedOptionStatus {
+  optionId: number;
+  voterNames: string[];
+}
+
+export interface VoteParticipationResponse {
+  totalParticipantCount: number;
+  anonymousOptionStatuses?: AnonymousOptionStatus[];
+  identifiedOptionStatuses?: IdentifiedOptionStatus[];
+}
+
+export interface VoteEndedResponse {
+  selectedOptionIds: number[];
+}
+
+export interface VoteWidgetDetail {
+  id: number;
+  title: string;
+  isAnonymous: boolean;
+  isMultiSelectable: boolean;
+  status: VoteStatus;
+  options: VoteOptionResponse[];
+  participationResponse: VoteParticipationResponse;
+  endedResponse?: VoteEndedResponse;
+}
+
+export interface CreateVoteWidgetResponse {
+  id: number;
+  title: string;
+  isAnonymous: boolean;
+  isMultiSelectable: boolean;
+  status: VoteStatus;
+  options: VoteOptionResponse[];
+}
+
+export interface CreateVoteWidgetRequest {
+  lessonId: number;
+  title: string;
+  options: string[];
+  isAnonymous: boolean;
+  isMultiSelectable: boolean;
+}
+
+export interface SubmitVoteRequest {
+  optionIds: number[];
+}
+
+export interface UpdateVoteStatusRequest {
+  status: VoteStatus;
+}

--- a/src/features/vote/ui/VoteStudent.tsx
+++ b/src/features/vote/ui/VoteStudent.tsx
@@ -10,6 +10,8 @@ interface VoteStudentProps {
   options: string[];
   selections: VoteSelectionItem[];
   isMultipleChoice: boolean;
+  isEnded?: boolean;
+  selectedOptionIds?: number[];
   onSubmit: (selectedIds: string[]) => void;
   onStatusClick?: () => void;
 }
@@ -20,6 +22,8 @@ function VoteStudent({
   options,
   selections,
   isMultipleChoice,
+  isEnded = false,
+  selectedOptionIds,
   onSubmit,
   onStatusClick,
 }: VoteStudentProps) {
@@ -53,12 +57,14 @@ function VoteStudent({
           selections={selections}
           selectedIds={selectedIds}
           onSelect={handleSelect}
+          isEnded={isEnded}
+          selectedOptionIds={selectedOptionIds}
         />
         <Footer
           onStatusClick={onStatusClick}
           onSubmitClick={handleSubmit}
           submitLabel="제출하기"
-          isSubmitDisabled={selectedIds.length === 0}
+          isSubmitDisabled={isEnded || selectedIds.length === 0}
         />
       </div>
     </StudentWidgetContainer>

--- a/src/features/vote/ui/VoteTeacher.tsx
+++ b/src/features/vote/ui/VoteTeacher.tsx
@@ -8,6 +8,8 @@ interface VoteTeacherProps {
   description: string;
   options: string[];
   selections: VoteSelectionItem[];
+  isEnded?: boolean;
+  selectedOptionIds?: number[];
   onStatusClick?: () => void;
   onStopClick?: () => void;
 }
@@ -17,6 +19,8 @@ function VoteTeacher({
   description,
   options,
   selections,
+  isEnded = false,
+  selectedOptionIds,
   onStatusClick,
   onStopClick,
 }: VoteTeacherProps) {
@@ -27,11 +31,17 @@ function VoteTeacher({
           <p className="flex-1 body-regular text-black-500">{description}</p>
           <OptionBadge options={options} />
         </div>
-        <SelectionList variant="teacher" selections={selections} />
+        <SelectionList
+          variant="teacher"
+          selections={selections}
+          selectedOptionIds={selectedOptionIds}
+        />
         <Footer
           onStatusClick={onStatusClick}
           onSubmitClick={onStopClick}
           submitLabel="종료하기"
+          statusLabel={isEnded ? '결과' : '현황'}
+          isSubmitDisabled={isEnded}
         />
       </div>
     </TeacherWidgetContainer>

--- a/src/features/vote/ui/blocks/Footer.tsx
+++ b/src/features/vote/ui/blocks/Footer.tsx
@@ -5,6 +5,7 @@ interface FooterProps {
   onStatusClick?: () => void;
   onSubmitClick?: () => void;
   submitLabel?: string;
+  statusLabel?: string;
   isSubmitDisabled?: boolean;
 }
 
@@ -12,11 +13,12 @@ function Footer({
   onStatusClick,
   onSubmitClick,
   submitLabel = '제출하기',
+  statusLabel = '현황',
   isSubmitDisabled = false,
 }: FooterProps) {
   return (
     <div className="flex flex-row justify-between items-center w-full h-8">
-      <StatusButton onClick={onStatusClick} />
+      <StatusButton onClick={onStatusClick} label={statusLabel} />
       <Button
         variant="blue"
         size="xs"

--- a/src/features/vote/ui/blocks/SelectionList.tsx
+++ b/src/features/vote/ui/blocks/SelectionList.tsx
@@ -113,23 +113,12 @@ function TeacherList({
           >
             <div className="relative">
               {isWinner && (
-                <svg
-                  width="20"
-                  height="14"
-                  viewBox="0 0 20 14"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="absolute -top-3 left-1/2 -translate-x-1/2 -rotate-12"
+                <img
+                  src="/icons/crown.svg"
+                  alt=""
                   aria-hidden="true"
-                >
-                  <path
-                    d="M2 12 L1 3 L5 6 L10 2 L15 6 L19 3 L18 12 Z"
-                    fill="#FBBF24"
-                    stroke="#D97706"
-                    strokeWidth="0.6"
-                    strokeLinejoin="round"
-                  />
-                </svg>
+                  className="absolute -top-3 left-1/2 -translate-x-1/2 rotate-12"
+                />
               )}
               <SelectionButton
                 label={String(index + 1)}

--- a/src/features/vote/ui/blocks/SelectionList.tsx
+++ b/src/features/vote/ui/blocks/SelectionList.tsx
@@ -111,13 +111,15 @@ function TeacherList({
             key={selection.id}
             className="flex flex-row items-center gap-2 w-full"
           >
-            <div className="relative">
+            <div className="relative w-12 h-12">
               {isWinner && (
                 <img
                   src="/icons/crown.svg"
                   alt=""
                   aria-hidden="true"
-                  className="absolute -top-3 left-1/2 -translate-x-1/2 rotate-12"
+                  width={20}
+                  height={14}
+                  className="absolute -top-3 left-6.5 rotate-25"
                 />
               )}
               <SelectionButton

--- a/src/features/vote/ui/blocks/SelectionList.tsx
+++ b/src/features/vote/ui/blocks/SelectionList.tsx
@@ -13,10 +13,13 @@ interface StudentSelectionListProps {
   selections: VoteSelectionItem[];
   selectedIds: string[];
   onSelect: (id: string) => void;
+  isEnded?: boolean;
+  selectedOptionIds?: number[];
 }
 
 interface TeacherSelectionListProps {
   selections: VoteSelectionItem[];
+  selectedOptionIds?: number[];
 }
 
 interface EditableSelectionListProps {
@@ -36,11 +39,18 @@ function StudentList({
   selections,
   selectedIds,
   onSelect,
+  isEnded = false,
+  selectedOptionIds,
 }: StudentSelectionListProps) {
   return (
     <ul className="flex flex-col gap-2.5 w-full">
       {selections.map((selection, index) => {
-        const isSelected = selectedIds.includes(selection.id);
+        const isWinner =
+          selectedOptionIds?.includes(Number(selection.id)) ?? false;
+        const isHighlighted = isEnded
+          ? isWinner
+          : selectedIds.includes(selection.id);
+        const handleClick = isEnded ? undefined : () => onSelect(selection.id);
         return (
           <li
             key={selection.id}
@@ -48,17 +58,19 @@ function StudentList({
           >
             <SelectionButton
               label={String(index + 1)}
-              variant={isSelected ? 'selected' : 'default'}
-              onClick={() => onSelect(selection.id)}
+              variant={isHighlighted ? 'selected' : 'default'}
+              onClick={handleClick}
               ariaLabel={`선택지 ${index + 1}: ${selection.label}`}
             />
             <div className="relative flex-1">
               <button
                 type="button"
-                onClick={() => onSelect(selection.id)}
+                onClick={handleClick}
+                disabled={isEnded}
                 className={cn(
-                  'flex flex-row items-center px-5 py-4 h-12 w-full rounded-xl border-2 overflow-hidden cursor-pointer',
-                  isSelected ? 'border-blue-300' : 'border-black-200',
+                  'flex flex-row items-center px-5 py-4 h-12 w-full rounded-xl border-2 overflow-hidden',
+                  isHighlighted ? 'border-blue-300' : 'border-black-200',
+                  isEnded ? 'cursor-default' : 'cursor-pointer',
                 )}
                 style={
                   selection.votedPercentage !== undefined
@@ -85,42 +97,70 @@ function StudentList({
   );
 }
 
-function TeacherList({ selections }: TeacherSelectionListProps) {
+function TeacherList({
+  selections,
+  selectedOptionIds,
+}: TeacherSelectionListProps) {
   return (
     <ul className="flex flex-col gap-2.5 w-full">
-      {selections.map((selection, index) => (
-        <li
-          key={selection.id}
-          className="flex flex-row items-center gap-2 w-full"
-        >
-          <SelectionButton
-            label={String(index + 1)}
-            variant="default"
-            ariaLabel={`선택지 ${index + 1}: ${selection.label}`}
-          />
-          <div className="relative flex-1">
-            <div
-              className="flex flex-row items-center px-5 py-4 h-12 rounded-xl border-2 border-black-200 overflow-hidden"
-              style={
-                selection.votedPercentage !== undefined
-                  ? {
-                      background: `linear-gradient(90deg, rgba(0, 24, 236, 0.17) ${selection.votedPercentage}%, #FEFEFE ${selection.votedPercentage}%)`,
-                    }
-                  : {}
-              }
-            >
-              <span className="flex-1 text-left body-medium text-black-500">
-                {selection.label}
-              </span>
-              {selection.voteCount !== undefined && (
-                <span className="absolute right-5 top-4 body-medium text-black-200">
-                  {selection.voteCount}명
-                </span>
+      {selections.map((selection, index) => {
+        const isWinner =
+          selectedOptionIds?.includes(Number(selection.id)) ?? false;
+        return (
+          <li
+            key={selection.id}
+            className="flex flex-row items-center gap-2 w-full"
+          >
+            <div className="relative">
+              {isWinner && (
+                <svg
+                  width="20"
+                  height="14"
+                  viewBox="0 0 20 14"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="absolute -top-3 left-1/2 -translate-x-1/2 -rotate-12"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M2 12 L1 3 L5 6 L10 2 L15 6 L19 3 L18 12 Z"
+                    fill="#FBBF24"
+                    stroke="#D97706"
+                    strokeWidth="0.6"
+                    strokeLinejoin="round"
+                  />
+                </svg>
               )}
+              <SelectionButton
+                label={String(index + 1)}
+                variant="default"
+                ariaLabel={`선택지 ${index + 1}: ${selection.label}`}
+              />
             </div>
-          </div>
-        </li>
-      ))}
+            <div className="relative flex-1">
+              <div
+                className="flex flex-row items-center px-5 py-4 h-12 rounded-xl border-2 border-black-200 overflow-hidden"
+                style={
+                  selection.votedPercentage !== undefined
+                    ? {
+                        background: `linear-gradient(90deg, rgba(0, 24, 236, 0.17) ${selection.votedPercentage}%, #FEFEFE ${selection.votedPercentage}%)`,
+                      }
+                    : {}
+                }
+              >
+                <span className="flex-1 text-left body-medium text-black-500">
+                  {selection.label}
+                </span>
+                {selection.voteCount !== undefined && (
+                  <span className="absolute right-5 top-4 body-medium text-black-200">
+                    {selection.voteCount}명
+                  </span>
+                )}
+              </div>
+            </div>
+          </li>
+        );
+      })}
     </ul>
   );
 }
@@ -187,19 +227,26 @@ function EditableList({
 
 function SelectionList({ variant, ...rest }: SelectionListProps) {
   if (variant === 'student') {
-    const { selections, selectedIds, onSelect } =
+    const { selections, selectedIds, onSelect, isEnded, selectedOptionIds } =
       rest as StudentSelectionListProps;
     return (
       <StudentList
         selections={selections}
         selectedIds={selectedIds}
         onSelect={onSelect}
+        isEnded={isEnded}
+        selectedOptionIds={selectedOptionIds}
       />
     );
   }
   if (variant === 'teacher') {
-    const { selections } = rest as TeacherSelectionListProps;
-    return <TeacherList selections={selections} />;
+    const { selections, selectedOptionIds } = rest as TeacherSelectionListProps;
+    return (
+      <TeacherList
+        selections={selections}
+        selectedOptionIds={selectedOptionIds}
+      />
+    );
   }
   const { selections, onChangeLabel, onRemove } =
     rest as EditableSelectionListProps;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -2,10 +2,12 @@ import { userHandlers } from '../features/example/api/example.mock.ts';
 import { memoHandlers } from '../features/memo/api/memo.mock';
 import { lessonHandlers } from '../features/lesson/api/lesson.mock';
 import { guestHandlers } from '../features/guest/api/guest.mock';
+import { voteHandlers } from '../features/vote/api/vote.mock';
 
 export const handlers = [
   ...userHandlers,
   ...memoHandlers,
   ...lessonHandlers,
   ...guestHandlers,
+  ...voteHandlers,
 ];

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -27,11 +27,13 @@ import { fetchMemoWidget } from '@/features/memo/api/memo.api';
 import {
   useCreateVoteWidgetMutation,
   useSubmitVoteMutation,
+  useUpdateVoteStatusMutation,
 } from '@/features/vote/api/vote.queries';
 import { fetchVoteWidget } from '@/features/vote/api/vote.api';
 import type {
   VoteOptionResponse,
   VoteParticipationResponse,
+  VoteStatus,
 } from '@/features/vote/api/vote.types';
 import SiteHeader from '@/shared/components/widget/dashboard-header/DashboardHeader';
 import DashboardHeader from '@/features/dashboard/ui/dashboard-header/DashboardHeader';
@@ -67,6 +69,8 @@ type VoteWidget = {
   description: string;
   selections: VoteSelectionItem[];
   options: string[];
+  status: VoteStatus;
+  endedSelectedOptionIds?: number[];
 };
 
 type NoteWidget = {
@@ -187,6 +191,7 @@ function DashBoardPage() {
   const createMemoMutation = useCreateMemoWidgetMutation(authToken);
   const createVoteMutation = useCreateVoteWidgetMutation(authToken);
   const submitVoteMutation = useSubmitVoteMutation(authToken);
+  const updateVoteStatusMutation = useUpdateVoteStatusMutation(authToken);
 
   useEffect(() => {
     if (hasInitializedRef.current) return;
@@ -227,6 +232,8 @@ function DashBoardPage() {
               data.isAnonymous,
               data.isMultiSelectable,
             ),
+            status: data.status,
+            endedSelectedOptionIds: data.endedResponse?.selectedOptionIds,
           }),
         );
         setWidgets([...memoWidgets, ...voteWidgets]);
@@ -352,6 +359,7 @@ function DashBoardPage() {
                 createdVote.isAnonymous,
                 createdVote.isMultiSelectable,
               ),
+              status: createdVote.status,
             },
           ]);
           setActiveCreateModal(null);
@@ -388,6 +396,40 @@ function DashBoardPage() {
             );
           } catch (error) {
             console.error('투표 결과 갱신 실패', error);
+          }
+        },
+      },
+    );
+  }
+
+  function handleVoteEndSubmit(voteWidgetId: number) {
+    updateVoteStatusMutation.mutate(
+      {
+        voteWidgetId,
+        body: { status: 'ENDED' },
+      },
+      {
+        onSuccess: async () => {
+          try {
+            const updatedVote = await fetchVoteWidget(voteWidgetId, authToken);
+            setWidgets((previous) =>
+              previous.map((widget) =>
+                widget.type === 'vote' && widget.voteWidgetId === voteWidgetId
+                  ? {
+                      ...widget,
+                      status: updatedVote.status,
+                      selections: buildVoteSelections(
+                        updatedVote.options,
+                        updatedVote.participationResponse,
+                      ),
+                      endedSelectedOptionIds:
+                        updatedVote.endedResponse?.selectedOptionIds,
+                    }
+                  : widget,
+              ),
+            );
+          } catch (error) {
+            console.error('투표 종료 후 갱신 실패', error);
           }
         },
       },
@@ -444,6 +486,13 @@ function DashBoardPage() {
             description={widget.description}
             selections={widget.selections}
             options={widget.options}
+            isEnded={widget.status === 'ENDED'}
+            selectedOptionIds={widget.endedSelectedOptionIds}
+            onStopClick={() => {
+              if (widget.voteWidgetId !== undefined) {
+                handleVoteEndSubmit(widget.voteWidgetId);
+              }
+            }}
           />
         ) : (
           <VoteStudent
@@ -452,6 +501,8 @@ function DashBoardPage() {
             selections={widget.selections}
             options={widget.options}
             isMultipleChoice={widget.options.includes('복수선택')}
+            isEnded={widget.status === 'ENDED'}
+            selectedOptionIds={widget.endedSelectedOptionIds}
             onSubmit={(selectedIds) => {
               if (widget.voteWidgetId !== undefined) {
                 handleVoteStudentSubmit(widget.voteWidgetId, selectedIds);

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -28,11 +28,11 @@ import {
   useCreateVoteWidgetMutation,
   useSubmitVoteMutation,
 } from '@/features/vote/api/vote.queries';
-import {
-  fetchVoteWidget,
-  type VoteOptionResponse,
-  type VoteParticipationResponse,
-} from '@/features/vote/api/vote.api';
+import { fetchVoteWidget } from '@/features/vote/api/vote.api';
+import type {
+  VoteOptionResponse,
+  VoteParticipationResponse,
+} from '@/features/vote/api/vote.types';
 import SiteHeader from '@/shared/components/widget/dashboard-header/DashboardHeader';
 import DashboardHeader from '@/features/dashboard/ui/dashboard-header/DashboardHeader';
 import AddWidgetModal from '@/features/dashboard/modal/add-widget-modal/AddWidgetModal';

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -21,6 +21,12 @@ import type { VoteSelectionItem } from '@/features/vote/ui/blocks/SelectionList'
 import { useLessonWidgetIdsQuery } from '@/features/lesson/api/lesson.queries';
 import { useCreateMemoWidgetMutation } from '@/features/memo/api/memo.queries';
 import { fetchMemoWidget } from '@/features/memo/api/memo.api';
+import { useCreateVoteWidgetMutation } from '@/features/vote/api/vote.queries';
+import {
+  fetchVoteWidget,
+  type VoteOptionResponse,
+  type VoteParticipationResponse,
+} from '@/features/vote/api/vote.api';
 import SiteHeader from '@/shared/components/widget/dashboard-header/DashboardHeader';
 import DashboardHeader from '@/features/dashboard/ui/dashboard-header/DashboardHeader';
 import AddWidgetModal from '@/features/dashboard/modal/add-widget-modal/AddWidgetModal';
@@ -45,6 +51,7 @@ type QuizWidget = {
 type VoteWidget = {
   type: 'vote';
   id: string;
+  voteWidgetId?: number;
   title: string;
   description: string;
   selections: VoteSelectionItem[];
@@ -98,6 +105,41 @@ function SortableWidget({ widget, children }: SortableWidgetProps) {
   );
 }
 
+function buildVoteSettingBadges(
+  isAnonymous: boolean,
+  isMultiSelectable: boolean,
+): string[] {
+  const badges: string[] = [];
+  if (isAnonymous) badges.push('익명');
+  if (isMultiSelectable) badges.push('복수선택');
+  return badges;
+}
+
+function buildVoteSelections(
+  options: VoteOptionResponse[],
+  participation?: VoteParticipationResponse,
+): VoteSelectionItem[] {
+  const totalParticipantCount = participation?.totalParticipantCount ?? 0;
+  return options.map((option) => {
+    const anonymousCount = participation?.anonymousOptionStatuses?.find(
+      (status) => status.optionId === option.id,
+    )?.count;
+    const identifiedCount = participation?.identifiedOptionStatuses?.find(
+      (status) => status.optionId === option.id,
+    )?.voterNames.length;
+    const voteCount = anonymousCount ?? identifiedCount ?? 0;
+    return {
+      id: String(option.id),
+      label: option.content,
+      voteCount,
+      votedPercentage:
+        totalParticipantCount > 0
+          ? Math.round((voteCount / totalParticipantCount) * 100)
+          : 0,
+    };
+  });
+}
+
 function DashBoardPage() {
   const {
     lessonCode = '',
@@ -125,35 +167,64 @@ function DashBoardPage() {
     () => widgetIdsData?.widgets.memo ?? [],
     [widgetIdsData],
   );
+  const voteWidgetIds = useMemo(
+    () => widgetIdsData?.widgets.vote ?? [],
+    [widgetIdsData],
+  );
   const createMemoMutation = useCreateMemoWidgetMutation(authToken);
+  const createVoteMutation = useCreateVoteWidgetMutation(authToken);
 
   useEffect(() => {
     if (hasInitializedRef.current) return;
-    if (memoWidgetIds.length === 0) return;
     if (!authToken) return;
+    if (!widgetIdsData) return;
 
-    const loadMemoWidgets = async () => {
+    const loadWidgets = async () => {
       try {
-        const memoWidgetDataArray = await Promise.all(
-          memoWidgetIds.map((id) => fetchMemoWidget(id, authToken)),
-        );
-        setWidgets(
-          memoWidgetDataArray.map((data) => ({
-            type: 'note' as const,
+        const [memoWidgetDataArray, voteWidgetDataArray] = await Promise.all([
+          Promise.all(
+            memoWidgetIds.map((id) => fetchMemoWidget(id, authToken)),
+          ),
+          Promise.all(
+            voteWidgetIds.map((id) => fetchVoteWidget(id, authToken)),
+          ),
+        ]);
+        const memoWidgets: DashboardWidget[] = memoWidgetDataArray.map(
+          (data) => ({
+            type: 'note',
             id: String(data.id),
             memoWidgetId: data.id,
             title: data.title,
             content: data.content,
-          })),
+          }),
         );
+        const voteWidgets: DashboardWidget[] = voteWidgetDataArray.map(
+          (data) => ({
+            type: 'vote',
+            id: String(data.id),
+            voteWidgetId: data.id,
+            title: data.title,
+            description: '',
+            selections: buildVoteSelections(
+              data.options,
+              data.participationResponse,
+            ),
+            options: buildVoteSettingBadges(
+              data.isAnonymous,
+              data.isMultiSelectable,
+            ),
+          }),
+        );
+        setWidgets([...memoWidgets, ...voteWidgets]);
         hasInitializedRef.current = true;
-      } catch {
+      } catch (error) {
+        console.error('위젯 초기 로드 실패', error);
         hasInitializedRef.current = true;
       }
     };
 
-    loadMemoWidgets();
-  }, [memoWidgetIds, authToken]);
+    loadWidgets();
+  }, [widgetIdsData, memoWidgetIds, voteWidgetIds, authToken]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -238,20 +309,41 @@ function DashBoardPage() {
     selections: VoteSelectionItem[];
     options: { id: string; label: string; enabled: boolean }[];
   }) {
-    setWidgets((previous) => [
-      ...previous,
+    if (!lessonId) return;
+    const isAnonymous =
+      data.options.find((option) => option.id === 'anonymous')?.enabled ??
+      false;
+    const isMultiSelectable =
+      data.options.find((option) => option.id === 'multiple')?.enabled ?? false;
+    createVoteMutation.mutate(
       {
-        type: 'vote',
-        id: crypto.randomUUID(),
+        lessonId,
         title: data.title,
-        description: data.description,
-        selections: data.selections,
-        options: data.options
-          .filter((option) => option.enabled)
-          .map((option) => option.label),
+        options: data.selections.map((selection) => selection.label),
+        isAnonymous,
+        isMultiSelectable,
       },
-    ]);
-    setActiveCreateModal(null);
+      {
+        onSuccess: (createdVote) => {
+          setWidgets((previous) => [
+            ...previous,
+            {
+              type: 'vote',
+              id: String(createdVote.id),
+              voteWidgetId: createdVote.id,
+              title: createdVote.title,
+              description: data.description,
+              selections: buildVoteSelections(createdVote.options),
+              options: buildVoteSettingBadges(
+                createdVote.isAnonymous,
+                createdVote.isMultiSelectable,
+              ),
+            },
+          ]);
+          setActiveCreateModal(null);
+        },
+      },
+    );
   }
 
   function handleQuizEnd(widgetId: string) {

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -107,7 +107,7 @@ function SortableWidget({ widget, children }: SortableWidgetProps) {
         transition,
         opacity: isDragging ? 0.5 : 1,
       }}
-      className="mb-5 break-inside-avoid cursor-grab active:cursor-grabbing"
+      className="cursor-grab active:cursor-grabbing"
       {...attributes}
       {...listeners}
     >
@@ -500,73 +500,75 @@ function DashBoardPage() {
   }
 
   return (
-    <div className="w-full">
+    <div className="flex flex-col h-screen w-full">
       <SiteHeader entryCode={lessonCode} participantCount={0} />
-      <DashboardHeader
-        lessonName={lessonName}
-        teacherName={teacherName}
-        onOpenModal={isTeacher ? handleOpenAddModal : undefined}
-      />
-      <div className="px-30 py-6">
-        {widgets.length === 0 && (
-          <div className="flex w-full items-center justify-center py-20">
-            <p className="body-medium text-black-200">
-              {isTeacher
-                ? '위젯을 생성해주세요.'
-                : '아직 생성된 위젯이 없습니다.'}
-            </p>
-          </div>
-        )}
-        {widgets.length > 0 && isTeacher && (
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragEnd={handleDragEnd}
-          >
-            <SortableContext
-              items={widgets.map((widget) => widget.id)}
-              strategy={rectSortingStrategy}
-            >
-              <div className="columns-1 gap-5 md:columns-2 lg:columns-3 xl:columns-4">
+      <main className="flex-1 relative overflow-hidden">
+        <div className="absolute inset-0 overflow-auto">
+          <DashboardHeader
+            lessonName={lessonName}
+            teacherName={teacherName}
+            onOpenModal={isTeacher ? handleOpenAddModal : undefined}
+          />
+          <div className="px-30 py-6">
+            {widgets.length === 0 && (
+              <div className="flex w-full items-center justify-center py-20">
+                <p className="body-medium text-black-200">
+                  {isTeacher
+                    ? '위젯을 생성해주세요.'
+                    : '아직 생성된 위젯이 없습니다.'}
+                </p>
+              </div>
+            )}
+            {widgets.length > 0 && isTeacher && (
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={widgets.map((widget) => widget.id)}
+                  strategy={rectSortingStrategy}
+                >
+                  <div className="grid gap-5 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 min-[1920px]:grid-cols-4">
+                    {widgets.map((widget) => (
+                      <SortableWidget key={widget.id} widget={widget}>
+                        {renderWidget(widget)}
+                      </SortableWidget>
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
+            )}
+            {widgets.length > 0 && !isTeacher && (
+              <div className="grid gap-5 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 min-[1920px]:grid-cols-4">
                 {widgets.map((widget) => (
-                  <SortableWidget key={widget.id} widget={widget}>
-                    {renderWidget(widget)}
-                  </SortableWidget>
+                  <div key={widget.id}>{renderWidget(widget)}</div>
                 ))}
               </div>
-            </SortableContext>
-          </DndContext>
-        )}
-        {widgets.length > 0 && !isTeacher && (
-          <div className="columns-1 gap-5 md:columns-2 lg:columns-3 xl:columns-4">
-            {widgets.map((widget) => (
-              <div key={widget.id} className="mb-5 break-inside-avoid">
-                {renderWidget(widget)}
-              </div>
-            ))}
+            )}
           </div>
-        )}
-      </div>
-      <AddWidgetModal
-        isOpen={isAddModalOpen}
-        onClose={handleCloseAddModal}
-        onSelectWidget={handleSelectWidget}
-      />
-      <QuizCreate
-        isOpen={activeCreateModal === 'quiz'}
-        onClose={handleCloseCreateModal}
-        onSubmit={handleQuizSubmit}
-      />
-      <VoteCreate
-        isOpen={activeCreateModal === 'vote'}
-        onCancel={handleCloseCreateModal}
-        onSubmit={handleVoteSubmit}
-      />
-      <MemoCreate
-        isOpen={isMemoCreateOpen}
-        onClose={handleCloseMemoCreateModal}
-        onSubmit={handleMemoSubmit}
-      />
+        </div>
+        <AddWidgetModal
+          isOpen={isAddModalOpen}
+          onClose={handleCloseAddModal}
+          onSelectWidget={handleSelectWidget}
+        />
+        <QuizCreate
+          isOpen={activeCreateModal === 'quiz'}
+          onClose={handleCloseCreateModal}
+          onSubmit={handleQuizSubmit}
+        />
+        <VoteCreate
+          isOpen={activeCreateModal === 'vote'}
+          onCancel={handleCloseCreateModal}
+          onSubmit={handleVoteSubmit}
+        />
+        <MemoCreate
+          isOpen={isMemoCreateOpen}
+          onClose={handleCloseMemoCreateModal}
+          onSubmit={handleMemoSubmit}
+        />
+      </main>
     </div>
   );
 }

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -18,7 +18,10 @@ import { CSS } from '@dnd-kit/utilities';
 import type { WidgetName } from '@/shared/types/widget.type';
 import type { LectureMaterial } from '@/features/lecture-materials/types';
 import type { VoteSelectionItem } from '@/features/vote/ui/blocks/SelectionList';
-import { useLessonWidgetIdsQuery } from '@/features/lesson/api/lesson.queries';
+import {
+  useLessonQuery,
+  useLessonWidgetIdsQuery,
+} from '@/features/lesson/api/lesson.queries';
 import { useCreateMemoWidgetMutation } from '@/features/memo/api/memo.queries';
 import { fetchMemoWidget } from '@/features/memo/api/memo.api';
 import { useCreateVoteWidgetMutation } from '@/features/vote/api/vote.queries';
@@ -141,16 +144,10 @@ function buildVoteSelections(
 }
 
 function DashBoardPage() {
-  const {
-    lessonCode = '',
-    lessonId: lessonIdParam = '',
-    lessonName = '',
-    teacherName = '',
-  } = useParams<{
+  const { lessonCode = '', lessonId: lessonIdParam = '' } = useParams<{
+    role: string;
     lessonCode: string;
     lessonId: string;
-    lessonName: string;
-    teacherName: string;
   }>();
   const lessonId = Number(lessonIdParam);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
@@ -162,6 +159,9 @@ function DashBoardPage() {
   const hasInitializedRef = useRef(false);
 
   const authToken = localStorage.getItem('authToken') ?? '';
+  const { data: lessonData } = useLessonQuery(lessonId, authToken);
+  const lessonName = lessonData?.lessonName ?? '';
+  const teacherName = lessonData?.teacherName ?? '';
   const { data: widgetIdsData } = useLessonWidgetIdsQuery(lessonId, authToken);
   const memoWidgetIds = useMemo(
     () => widgetIdsData?.widgets.memo ?? [],

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -24,7 +24,10 @@ import {
 } from '@/features/lesson/api/lesson.queries';
 import { useCreateMemoWidgetMutation } from '@/features/memo/api/memo.queries';
 import { fetchMemoWidget } from '@/features/memo/api/memo.api';
-import { useCreateVoteWidgetMutation } from '@/features/vote/api/vote.queries';
+import {
+  useCreateVoteWidgetMutation,
+  useSubmitVoteMutation,
+} from '@/features/vote/api/vote.queries';
 import {
   fetchVoteWidget,
   type VoteOptionResponse,
@@ -183,6 +186,7 @@ function DashBoardPage() {
   );
   const createMemoMutation = useCreateMemoWidgetMutation(authToken);
   const createVoteMutation = useCreateVoteWidgetMutation(authToken);
+  const submitVoteMutation = useSubmitVoteMutation(authToken);
 
   useEffect(() => {
     if (hasInitializedRef.current) return;
@@ -356,6 +360,40 @@ function DashBoardPage() {
     );
   }
 
+  function handleVoteStudentSubmit(
+    voteWidgetId: number,
+    selectedIds: string[],
+  ) {
+    submitVoteMutation.mutate(
+      {
+        voteWidgetId,
+        body: { optionIds: selectedIds.map(Number) },
+      },
+      {
+        onSuccess: async () => {
+          try {
+            const updatedVote = await fetchVoteWidget(voteWidgetId, authToken);
+            setWidgets((previous) =>
+              previous.map((widget) =>
+                widget.type === 'vote' && widget.voteWidgetId === voteWidgetId
+                  ? {
+                      ...widget,
+                      selections: buildVoteSelections(
+                        updatedVote.options,
+                        updatedVote.participationResponse,
+                      ),
+                    }
+                  : widget,
+              ),
+            );
+          } catch (error) {
+            console.error('투표 결과 갱신 실패', error);
+          }
+        },
+      },
+    );
+  }
+
   function handleQuizEnd(widgetId: string) {
     setWidgets((previous) =>
       previous.map((widget) =>
@@ -414,7 +452,11 @@ function DashBoardPage() {
             selections={widget.selections}
             options={widget.options}
             isMultipleChoice={widget.options.includes('복수선택')}
-            onSubmit={() => {}}
+            onSubmit={(selectedIds) => {
+              if (widget.voteWidgetId !== undefined) {
+                handleVoteStudentSubmit(widget.voteWidgetId, selectedIds);
+              }
+            }}
           />
         );
       case 'question':

--- a/src/page/dashboard/DashBoardPage.tsx
+++ b/src/page/dashboard/DashBoardPage.tsx
@@ -37,10 +37,15 @@ import QuizCreate, { type QuizCreateData } from '@/features/quiz/ui/QuizCreate';
 import VoteCreate from '@/features/vote/ui/VoteCreate';
 import MemoCreate, { type MemoCreateData } from '@/features/memo/ui/MemoCreate';
 import QuizTeacher from '@/features/quiz/ui/QuizTeacher';
+import QuizStudent from '@/features/quiz/ui/QuizStudent';
 import VoteTeacher from '@/features/vote/ui/VoteTeacher';
+import VoteStudent from '@/features/vote/ui/VoteStudent';
 import QuestionTeacher from '@/features/question/ui/QuestionTeacher';
+import QuestionStudent from '@/features/question/ui/QuestionStudent';
 import MemoTeacher from '@/features/memo/ui/MemoTeacher';
+import MemoStudent from '@/features/memo/ui/MemoStudent';
 import LectureMaterialsTeacher from '@/features/lecture-materials/ui/LectureMaterialsTeacher';
+import LectureMaterialsStudent from '@/features/lecture-materials/ui/LectureMaterialsStudent';
 
 type QuizWidget = {
   type: 'quiz';
@@ -144,12 +149,17 @@ function buildVoteSelections(
 }
 
 function DashBoardPage() {
-  const { lessonCode = '', lessonId: lessonIdParam = '' } = useParams<{
+  const {
+    role = 'teacher',
+    lessonCode = '',
+    lessonId: lessonIdParam = '',
+  } = useParams<{
     role: string;
     lessonCode: string;
     lessonId: string;
   }>();
   const lessonId = Number(lessonIdParam);
+  const isTeacher = role !== 'student';
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [activeCreateModal, setActiveCreateModal] = useState<WidgetName | null>(
     null,
@@ -370,7 +380,7 @@ function DashBoardPage() {
   function renderWidget(widget: DashboardWidget) {
     switch (widget.type) {
       case 'quiz':
-        return (
+        return isTeacher ? (
           <QuizTeacher
             question={widget.question}
             choices={widget.choices}
@@ -379,33 +389,67 @@ function DashBoardPage() {
             isEnded={widget.isEnded}
             onEnd={() => handleQuizEnd(widget.id)}
           />
+        ) : (
+          <QuizStudent
+            question={widget.question}
+            choices={widget.choices}
+            correctAnswerIndex={widget.correctAnswerIndex}
+            participantCount={0}
+            isEnded={widget.isEnded}
+            onSubmit={() => {}}
+          />
         );
       case 'vote':
-        return (
+        return isTeacher ? (
           <VoteTeacher
             title={widget.title}
             description={widget.description}
             selections={widget.selections}
             options={widget.options}
           />
+        ) : (
+          <VoteStudent
+            title={widget.title}
+            description={widget.description}
+            selections={widget.selections}
+            options={widget.options}
+            isMultipleChoice={widget.options.includes('복수선택')}
+            onSubmit={() => {}}
+          />
         );
       case 'question':
-        return (
+        return isTeacher ? (
           <QuestionTeacher
             questions={[]}
             currentPage={1}
             onPageChange={() => {}}
           />
+        ) : (
+          <QuestionStudent
+            questions={[]}
+            currentPage={1}
+            onPageChange={() => {}}
+            onSubmitQuestion={() => {}}
+          />
         );
       case 'note':
-        return <MemoTeacher title={widget.title} content={widget.content} />;
+        return isTeacher ? (
+          <MemoTeacher title={widget.title} content={widget.content} />
+        ) : (
+          <MemoStudent title={widget.title} memo={widget.content} />
+        );
       case 'file':
-        return (
+        return isTeacher ? (
           <LectureMaterialsTeacher
             materials={[] as LectureMaterial[]}
             onUpload={() => {}}
             onDownload={() => {}}
             onDelete={() => {}}
+          />
+        ) : (
+          <LectureMaterialsStudent
+            materials={[] as LectureMaterial[]}
+            onDownload={() => {}}
           />
         );
       default:
@@ -419,14 +463,19 @@ function DashBoardPage() {
       <DashboardHeader
         lessonName={lessonName}
         teacherName={teacherName}
-        onOpenModal={handleOpenAddModal}
+        onOpenModal={isTeacher ? handleOpenAddModal : undefined}
       />
       <div className="px-30 py-6">
-        {widgets.length === 0 ? (
+        {widgets.length === 0 && (
           <div className="flex w-full items-center justify-center py-20">
-            <p className="body-medium text-black-200">위젯을 생성해주세요.</p>
+            <p className="body-medium text-black-200">
+              {isTeacher
+                ? '위젯을 생성해주세요.'
+                : '아직 생성된 위젯이 없습니다.'}
+            </p>
           </div>
-        ) : (
+        )}
+        {widgets.length > 0 && isTeacher && (
           <DndContext
             sensors={sensors}
             collisionDetection={closestCenter}
@@ -445,6 +494,15 @@ function DashBoardPage() {
               </div>
             </SortableContext>
           </DndContext>
+        )}
+        {widgets.length > 0 && !isTeacher && (
+          <div className="columns-1 gap-5 md:columns-2 lg:columns-3 xl:columns-4">
+            {widgets.map((widget) => (
+              <div key={widget.id} className="mb-5 break-inside-avoid">
+                {renderWidget(widget)}
+              </div>
+            ))}
+          </div>
         )}
       </div>
       <AddWidgetModal

--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -12,7 +12,6 @@ import FindLessonModal from '@/features/main/components/modal/find-lesson-modal/
 import CreateLessonModal from '@/features/main/components/modal/create-lesson-modal/CreateLessonModal';
 import { useCreateLessonMutation } from '@/features/lesson/api/lesson.queries';
 import {
-  fetchLesson,
   authenticateLesson,
   joinLessonAsStudent,
 } from '@/features/lesson/api/lesson.api';
@@ -40,7 +39,6 @@ export default function MainPage() {
   const [submittedJoinCode, setSubmittedJoinCode] = useState('');
   const [submittedFindCode, setSubmittedFindCode] = useState('');
   const [lessonCode, setLessonCode] = useState<string>('');
-  const [teacherName, setTeacherName] = useState<string>('');
 
   const createLessonMutation = useCreateLessonMutation();
 
@@ -55,16 +53,13 @@ export default function MainPage() {
   useEffect(() => {
     if (createLessonMutation.isSuccess && createLessonMutation.data) {
       const lesson = createLessonMutation.data;
-      navigate(
-        `/dashboard/${lessonCode}/${lesson.lessonId}/${lesson.lessonName}/${teacherName}`,
-      );
+      navigate(`/dashboard/teacher/${lessonCode}/${lesson.lessonId}`);
     }
   }, [
     createLessonMutation.isSuccess,
     createLessonMutation.data,
     navigate,
     lessonCode,
-    teacherName,
   ]);
 
   const handleCloseModal = () => {
@@ -97,13 +92,7 @@ export default function MainPage() {
         { name: payload.studentName },
         guestCredentialsResponse.token,
       );
-      const lesson = await fetchLesson(
-        lessonId,
-        guestCredentialsResponse.token,
-      );
-      navigate(
-        `/dashboard/${payload.lessonCode}/${lessonId}/${lesson.lessonName}/${lesson.teacherName}`,
-      );
+      navigate(`/dashboard/student/${payload.lessonCode}/${lessonId}`);
     } catch {
       // eslint-disable-next-line no-empty
     }
@@ -120,12 +109,8 @@ export default function MainPage() {
       });
       localStorage.setItem('lessonAuthToken', authResponse.token);
       localStorage.setItem('authToken', authResponse.token);
-      const lesson = await fetchLesson(
-        authResponse.lessonId,
-        authResponse.token,
-      );
       navigate(
-        `/dashboard/${payload.lessonCode}/${authResponse.lessonId}/${lesson.lessonName}/${lesson.teacherName}`,
+        `/dashboard/teacher/${payload.lessonCode}/${authResponse.lessonId}`,
       );
     } catch {
       // eslint-disable-next-line no-empty
@@ -152,7 +137,6 @@ export default function MainPage() {
         },
         guestToken: guestCredentialsResponse.token,
       });
-      setTeacherName(payload.teacherName);
     } catch {
       // eslint-disable-next-line no-empty
     }

--- a/src/page/main/MainPage.tsx
+++ b/src/page/main/MainPage.tsx
@@ -143,45 +143,47 @@ export default function MainPage() {
   };
 
   return (
-    <div className="flex flex-col w-full">
+    <div className="flex flex-col h-screen w-full">
       <DashboardHeader logoOnly />
-      <main className="flex w-full justify-center px-30 py-10">
-        <div className="flex flex-col items-center w-full gap-20">
-          <section className="flex w-full gap-30 justify-between items-stretch">
-            <div className="flex flex-1 min-w-0">
-              <VideoSection
-                className="h-full w-full"
-                selectedId={selectedWidgetId}
-              />
-            </div>
-            <div className="flex flex-col gap-20 w-auto shrink-0">
-              <HeroSection />
-              <EntranceSection
-                onJoin={handleJoin}
-                onFind={handleFind}
-                onCreate={handleCreateCode}
-              />
-            </div>
-          </section>
-          <section className="flex flex-col gap-8 w-full">
-            <SectionDivider
-              className="flex items-center"
-              text="카드를 클릭해 위젯 기능을 미리 확인해보세요"
-            />
-            <div className="flex gap-9 w-full">
-              {WIDGET_DATA.map((widget) => (
-                <WidgetDescriptionCard
-                  key={widget.id}
-                  iconName={widget.id}
-                  title={widget.title}
-                  description={widget.description}
-                  isSelected={selectedWidgetId === widget.id}
-                  onClick={() => setSelectedWidgetId(widget.id)}
-                  className="flex-1"
+      <main className="flex-1 relative overflow-hidden">
+        <div className="absolute inset-0 overflow-auto flex justify-center px-30 py-10">
+          <div className="flex flex-col items-center w-full gap-20">
+            <section className="flex w-full gap-30 justify-between items-stretch">
+              <div className="flex flex-1 min-w-0">
+                <VideoSection
+                  className="h-full w-full"
+                  selectedId={selectedWidgetId}
                 />
-              ))}
-            </div>
-          </section>
+              </div>
+              <div className="flex flex-col gap-20 w-auto shrink-0">
+                <HeroSection />
+                <EntranceSection
+                  onJoin={handleJoin}
+                  onFind={handleFind}
+                  onCreate={handleCreateCode}
+                />
+              </div>
+            </section>
+            <section className="flex flex-col gap-8 w-full">
+              <SectionDivider
+                className="flex items-center"
+                text="카드를 클릭해 위젯 기능을 미리 확인해보세요"
+              />
+              <div className="flex gap-9 w-full">
+                {WIDGET_DATA.map((widget) => (
+                  <WidgetDescriptionCard
+                    key={widget.id}
+                    iconName={widget.id}
+                    title={widget.title}
+                    description={widget.description}
+                    isSelected={selectedWidgetId === widget.id}
+                    onClick={() => setSelectedWidgetId(widget.id)}
+                    className="flex-1"
+                  />
+                ))}
+              </div>
+            </section>
+          </div>
         </div>
         {openedModal === 'join' && (
           <JoinLessonModal

--- a/src/shared/components/ui/modal/Modal.tsx
+++ b/src/shared/components/ui/modal/Modal.tsx
@@ -12,7 +12,7 @@ function Modal({ title, isOpen, onClose, children }: ModalProps) {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="absolute inset-0 z-50 flex items-center justify-center px-4 py-4">
       <div
         aria-hidden="true"
         onClick={onClose}
@@ -22,15 +22,17 @@ function Modal({ title, isOpen, onClose, children }: ModalProps) {
         role="dialog"
         aria-modal="true"
         aria-labelledby="modal-title"
-        className="relative z-10 flex h-auto w-125 flex-col items-center gap-10 rounded-[28px] bg-black-0 p-8"
+        className="relative z-10 flex max-h-full w-125 flex-col items-center gap-10 rounded-[28px] bg-black-0 p-8"
       >
-        <div className="flex items-center justify-between w-full h-13">
+        <div className="flex items-center justify-between w-full h-13 shrink-0">
           <h2 id="modal-title" className="h2-semibold">
             {title}
           </h2>
           <IconButton iconName="close" shape="circle" onClick={onClose} />
         </div>
-        <div className="flex flex-col w-full gap-11">{children}</div>
+        <div className="flex flex-col w-full gap-11 flex-1 min-h-0 overflow-y-auto">
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/src/shared/components/widget/widget-container/WidgetContainer.tsx
+++ b/src/shared/components/widget/widget-container/WidgetContainer.tsx
@@ -37,7 +37,7 @@ function WidgetContainerBase({
   iconName,
   title,
   description,
-  width = 'w-130',
+  width = 'w-full max-w-130',
   children,
   showMore = false,
   onEditClick,


### PR DESCRIPTION
## 📋 PR 요약
투표 위젯 API를 백엔드와 연동하고, 학생/교사 진입 경로를 분기해 대시보드가 역할에 맞는 위젯 변형을 렌더하도록 구현하였습니다.

## 🎯 작업 배경 및 이유
- 투표 위젯 UI는 완성돼 있었으나 백엔드 API와 연결되지 않아 생성·조회·제출이 동작하지 않는 상태였습니다.
- 메인 페이지에서 학생(Join)과 교사(Find/Create) 진입 경로는 구분돼 있었지만 모두 동일한 교사용 대시보드로 라우팅되어, 학생도 "위젯 추가"와 DnD가 노출되고 교사용 변형 위젯만 보였습니다.

## 🔗 관련 링크
- 기획서(Notion): 
- 테크 스펙(Google Docs): 
- Figma: 
- Slack: 

## 💻 주요 변경 사항
**투표 API 레이어 (src/features/vote/api/)**

- `vote.api.ts` - createVoteWidget, fetchVoteWidget, deleteVoteWidget, submitVote, updateVoteStatus 5개 함수
- `vote.queries.ts` - TanStack Query 훅 5개
- `vote.mock.ts` - MSW handler 5개 (src/mocks/handlers.ts에 등록)
- `vote.types.ts` - 요청/응답 타입 정의를 함수 구현과 분리

**대시보드 역할 분기 (DashBoardPage.tsx)**

- role 파라미터로 isTeacher 판별
- renderWidget이 5종 위젯 모두 *Teacher/*Student 변형을 분기 선택
- 학생은 "+ 위젯 추가" 버튼 숨김, DnD 비활성화(일반 그리드), 빈 상태 메시지 분기
- DashboardHeader의 onOpenModal을 optional로 변경해 버튼 게이팅

## 🖼️ 스크린샷 / 화면 녹화

<img width="1918" height="862" alt="image" src="https://github.com/user-attachments/assets/fe322648-15f0-49a3-be6a-e3e24f81021a" />

<img width="1916" height="852" alt="image" src="https://github.com/user-attachments/assets/b77c3b95-bb88-49c3-b88f-7c8ca2eb74a8" />

<img width="1865" height="735" alt="image" src="https://github.com/user-attachments/assets/aff2c590-4bbe-4554-b666-6c0fa64fa6f4" />


## 💬 리뷰어에게